### PR TITLE
Clean up docs and code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 branch = true
-omit = tests/*
+omit =
+    tests/*
+    */_version.py

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
 max-line-length: 90
-extend-ignore =

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length: 90
+extend-ignore =

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+# Fixed Issues
+
+*Does this pull request fix any open issues? If so, list them here, one per line,
+each in the format `Fixes #<n>`. Delete this comment.*
+
+- Fixes #
+
+# Summary of Changes
+
+*Summarize the changes made by this pull request. Consider this a permanent record of the work you have done and make it sufficiently detailed and readable that a developer in the future would be able to get the complete picture without looking at the code changes. Skimming through the changed files will help you create the summary. Delete this comment.*
+
+- Summary
+
+# Known Problems
+
+*Are there any relevant problems not fixed by, or problems caused by, this pull request? Delete this comment.*
+
+- Problem

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,13 +11,27 @@ on:
     - cron: "21 11 * * 0"
 
 jobs:
+  flake8:
+    name: Flake8 tabulation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Flake8
+        run: |
+          pip install flake8
+          flake8 tabulation tests
+
   test:
     name: Test tabulation
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     steps:
       - name: Checkout

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,5 +28,5 @@ sphinx:
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   install:
-   - requirements: requirements.txt
+  install:
+  - requirements: requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ We use GitHub Issues to track enhancement requests. If you want to suggest an en
 
 ## I Want To Contribute Code
 
-> ### Legal Notice 
+> ### Legal Notice
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content, and that the content you contribute may be provided under the project license.
 
 We welcome all code contributions, including bug fixes, new features, and improvements to documentation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![GitHub release; latest by date](https://img.shields.io/github/v/release/SETI/rms-tabulation)](https://github.com/SETI/rms-tabulation/releases)
 [![GitHub Release Date](https://img.shields.io/github/release-date/SETI/rms-tabulation)](https://github.com/SETI/rms-tabulation/releases)
 [![Test Status](https://img.shields.io/github/actions/workflow/status/SETI/rms-tabulation/run-tests.yml?branch=main)](https://github.com/SETI/rms-tabulation/actions)
+[![Documentation Status](https://readthedocs.org/projects/rms-tabulation/badge/?version=latest)](https://rms-tabulation.readthedocs.io/en/latest/?badge=latest)
 [![Code coverage](https://img.shields.io/codecov/c/github/SETI/rms-tabulation/main?logo=codecov)](https://codecov.io/gh/SETI/rms-tabulation)
 <br />
 [![PyPI - Version](https://img.shields.io/pypi/v/rms-tabulation)](https://pypi.org/project/rms-tabulation)
@@ -21,11 +22,81 @@
 [![Number of GitHub stars](https://img.shields.io/github/stars/SETI/rms-tabulation)](https://github.com/SETI/rms-tabulation/stargazers)
 ![GitHub forks](https://img.shields.io/github/forks/SETI/rms-tabulation)
 
-# rms-tabulation
+# Introduction
 
-PDS Ring-Moon Systems Node, SETI Institute
+`tabulation` is a Python module that provides the `Tabulation` class. The `Tabulation`
+class represents a mathematical function by a sequence of linear interpolations between
+points defined by arrays of *x* and *y* coordinates.
 
-Supported versions: Python >= 3.8
+`tabulation` is a product of the [PDS Ring-Moon Systems Node](https://pds-rings.seti.org).
 
-The Tabulation class represents a function by a sequence of linear
-interpolations between points defined by arrays of x and y coordinates.
+# Installation
+
+The `tabulation` module is available via the `rms-tabulation` package on PyPI and can be
+installed with:
+
+```sh
+pip install rms-tabulation
+```
+
+# Getting Started
+
+The `Tabulation` class models a mathematical function by a series of (*x*,*y*) points and
+performs linear interpolation between them. The function is assumed to be zero outside of
+the defined *x* domain. However, if provided, one zero-valued point at either the
+beginning and/or the end of the *x* domain is considered to be valid data so that the
+interpolation can be anchored. If there is no zero-valued point provided, a step function
+is assumed.
+
+A variety of mathematical operations can be performed on `Tabulation` objects, including
+addition, subtracting, multiplication, division, integration, and finding the mean, FWHM,
+or square width. See the
+[module documentation](https://rms-.readthedocs.io/en/latest/module.html) for details.
+
+Here are some examples to get you started:
+
+```python
+>>> from tabulation import Tabulation
+>>> t1 = Tabulation([2, 4], [10, 10])  # Leading&trailing step function
+>>> t1.domain()
+(2., 4.)
+>>> t1([0,   1,   1.9, 2,   3,   3.9, 4,   5,   6])
+array([ 0.,  0.,  0., 10., 10., 10., 10.,  0.,  0.])
+>>> t1.mean()
+10.0
+
+>>> t2 = Tabulation([0, 2, 4], [0, 10, 10])  # Ramp on leading edge
+>>> t2.domain()
+(0., 4.)
+>>> t2([0,   1,   1.9,  2,   3,   3.9, 4,   5,   6])
+array([ 0.,  5.,  9.5, 10., 10., 10., 10.,  0.,  0.])
+>>> t2.mean()
+7.5
+
+>>> t3 = Tabulation([1, 3, 5], [5, 10, 5])  # Another step function
+>>> r1 = t1 - t3
+>>> r1.domain()
+(1.0, 5.0)
+>>> r1.x
+array([ 1.,   2.,   3.,   4.,   5.])  # Now includes all x points from both t1 and t3
+>>> r1.y
+array([-5. ,  2.5,  0. ,  2.5, -5. ])
+
+
+
+
+# Contributing
+
+Information on contributing to this package can be found in the
+[Contributing Guide](https://github.com/SETI/rms-/blob/main/CONTRIBUTING.md).
+
+# Links
+
+- [Documentation](https://rms-.readthedocs.io)
+- [Repository](https://github.com/SETI/rms-)
+- [Issue tracker](https://github.com/SETI/rms-/issues)
+- [PyPi](https://pypi.org/project/rms-)
+
+# Licensing
+
+This code is licensed under the [Apache License v2.0](https://github.com/SETI/rms-/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -56,9 +56,14 @@ end of the domain.
 A variety of mathematical operations can be performed on `Tabulation` objects, including
 addition, subtraction, multiplication, division, integration, and finding the X mean,
 FWHM, and square width. See the [module
-documentation](https://rms-.readthedocs.io/en/latest/module.html) for details.
+documentation](https://rms-tabulation.readthedocs.io/en/latest/module.html) for details.
 
 Here are some examples to get you started:
+
+        >>> t2 = Tabulation([0, 2, 4], [0, 5, 5])  # Ramp on leading edge
+        >>> t2.domain()
+        (0., 4.)
+        >>> t2([0,    1,    1.9,  2,    3,    3.9,  4,    5,    6])
 
 ```python
 >>> from tabulation import Tabulation
@@ -75,14 +80,14 @@ array([      0.,  0.,  0., 10., 10., 10., 10.,  0.,  0.])
 >>> t2 = Tabulation([0, 2, 4], [0, 5, 5])  # Ramp on leading edge
 >>> t2.domain()
 (0., 4.)
->>> r2 = t2([0,   1,   1.9,  2,   3,   3.9, 4,   5,   6])
-array([      0.,  5.,  9.5, 10., 10., 10., 10.,  0.,  0.])
+>>> r2 = t2([0,    1,  1.9, 2,  3,  3.9, 4,  5,  6])
+array([      0., 2.5, 4.75, 5., 5., 5. , 5., 0., 0.])
 >>> t2.x_mean()
 2.6666666666666665
 >>> t2.integral()
 15.0
 
->>> t3 = t1-t2
+>>> t3 = t2-t1
 >>> t3.domain()
 (0.0, 4.0)
 >>> r2-r1
@@ -90,21 +95,21 @@ array([ 0.  ,  2.5 ,  4.75, -5.  , -5.  , -5.  , -5.  ,  0.  ,  0.  ])
 >>> t3([0,       1,   1.9,   2,     3,     3.9,   4,     5,     6])
 array([ 0.  ,  2.5 ,  4.75, -5.  , -5.  , -5.  , -5.  ,  0.  ,  0.  ])
 >>> t3.integral()
-5.000000000000001
+-5.000000000000001
 ```
 
 # Contributing
 
 Information on contributing to this package can be found in the
-[Contributing Guide](https://github.com/SETI/rms-/blob/main/CONTRIBUTING.md).
+[Contributing Guide](https://github.com/SETI/rms-tabulation/blob/main/CONTRIBUTING.md).
 
 # Links
 
-- [Documentation](https://rms-.readthedocs.io)
-- [Repository](https://github.com/SETI/rms-)
-- [Issue tracker](https://github.com/SETI/rms-/issues)
-- [PyPi](https://pypi.org/project/rms-)
+- [Documentation](https://rms-tabulation.readthedocs.io)
+- [Repository](https://github.com/SETI/rms-tabulation)
+- [Issue tracker](https://github.com/SETI/rms-tabulation/issues)
+- [PyPi](https://pypi.org/project/rms-tabulation)
 
 # Licensing
 
-This code is licensed under the [Apache License v2.0](https://github.com/SETI/rms-/blob/main/LICENSE).
+This code is licensed under the [Apache License v2.0](https://github.com/SETI/rms-tabulation/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -42,16 +42,21 @@ pip install rms-tabulation
 # Getting Started
 
 The `Tabulation` class models a mathematical function by a series of (*x*,*y*) points and
-performs linear interpolation between them. The function is assumed to be zero outside of
-the defined *x* domain. However, if provided, one zero-valued point at either the
-beginning and/or the end of the *x* domain is considered to be valid data so that the
-interpolation can be anchored. If there is no zero-valued point provided, a step function
-is assumed.
+performs linear interpolation between them. Although optimized to model filter bandpasses
+and spectral flux, the class is sufficiently general to be used in a wide range of
+applications.
+
+The mathematical function is treated as equal to zero outside the domain of the *x*
+coordinates, with a step at the provided leading and trailing *x* coordinates. In general,
+zero values (either supplied or computed) at either the leading or trailing ends are
+removed. However, if explicitly supplied, one leading and/or trailing zero value is
+considered significant because it anchors the interpolation of a ramp at the beginning or
+end of the domain.
 
 A variety of mathematical operations can be performed on `Tabulation` objects, including
-addition, subtracting, multiplication, division, integration, and finding the mean, FWHM,
-or square width. See the
-[module documentation](https://rms-.readthedocs.io/en/latest/module.html) for details.
+addition, subtraction, multiplication, division, integration, and finding the X mean,
+FWHM, and square width. See the [module
+documentation](https://rms-.readthedocs.io/en/latest/module.html) for details.
 
 Here are some examples to get you started:
 
@@ -60,30 +65,33 @@ Here are some examples to get you started:
 >>> t1 = Tabulation([2, 4], [10, 10])  # Leading&trailing step function
 >>> t1.domain()
 (2., 4.)
->>> t1([0,   1,   1.9, 2,   3,   3.9, 4,   5,   6])
-array([ 0.,  0.,  0., 10., 10., 10., 10.,  0.,  0.])
->>> t1.mean()
-10.0
+>>> r1 = t1([0,   1,   1.9, 2,   3,   3.9, 4,   5,   6])
+array([      0.,  0.,  0., 10., 10., 10., 10.,  0.,  0.])
+>>> t1.x_mean()
+3.0
+>>> t1.integral()
+20.0
 
->>> t2 = Tabulation([0, 2, 4], [0, 10, 10])  # Ramp on leading edge
+>>> t2 = Tabulation([0, 2, 4], [0, 5, 5])  # Ramp on leading edge
 >>> t2.domain()
 (0., 4.)
->>> t2([0,   1,   1.9,  2,   3,   3.9, 4,   5,   6])
-array([ 0.,  5.,  9.5, 10., 10., 10., 10.,  0.,  0.])
->>> t2.mean()
-7.5
+>>> r2 = t2([0,   1,   1.9,  2,   3,   3.9, 4,   5,   6])
+array([      0.,  5.,  9.5, 10., 10., 10., 10.,  0.,  0.])
+>>> t2.x_mean()
+2.6666666666666665
+>>> t2.integral()
+15.0
 
->>> t3 = Tabulation([1, 3, 5], [5, 10, 5])  # Another step function
->>> r1 = t1 - t3
->>> r1.domain()
-(1.0, 5.0)
->>> r1.x
-array([ 1.,   2.,   3.,   4.,   5.])  # Now includes all x points from both t1 and t3
->>> r1.y
-array([-5. ,  2.5,  0. ,  2.5, -5. ])
-
-
-
+>>> t3 = t1-t2
+>>> t3.domain()
+(0.0, 4.0)
+>>> r2-r1
+array([ 0.  ,  2.5 ,  4.75, -5.  , -5.  , -5.  , -5.  ,  0.  ,  0.  ])
+>>> t3([0,       1,   1.9,   2,     3,     3.9,   4,     5,     6])
+array([ 0.  ,  2.5 ,  4.75, -5.  , -5.  , -5.  , -5.  ,  0.  ,  0.  ])
+>>> t3.integral()
+5.000000000000001
+```
 
 # Contributing
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,32 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'tabulation'
+copyright = '2024, PDS Ring-Moon Systems Node'
+author = 'PDS Ring-Moon Systems Node'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['myst_parser', 'sphinx.ext.autodoc', 'sphinx.ext.napoleon',
+              'sphinx.ext.viewcode']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,25 @@
+.. solar documentation master file, created by
+   sphinx-quickstart on Fri May 24 12:58:54 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to ``tabulation``'s documentation!
+==========================================
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_
+   :start-after: forks/SETI/rms-tabulation)
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   module
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/module.rst
+++ b/docs/module.rst
@@ -1,0 +1,10 @@
+``tabulation`` Module
+=====================
+
+.. automodule:: tabulation
+    :member-order: bysource
+    :members:
+    :undoc-members:
+    :special-members:
+    :show-inheritance:
+    :exclude-members: __dict__, __hash__, __module__, __weakref__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/SETI/rms-tabulation"
+Documentation = "https://rms-tabulation.readthedocs.io/en/latest"
 Repository = "https://github.com/SETI/rms-tabulation"
 Source = "https://github.com/SETI/rms-tabulation"
 Issues = "https://github.com/SETI/rms-tabulation/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 coverage
+flake8
+myst-parser
 numpy
 pytest
 scipy
+sphinx
+sphinxcontrib-napoleon
+sphinx-rtd-theme

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -17,6 +17,11 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 try:
+    from math import nextafter  # Only in Python 3.9 and later
+except ImportError:  # pragma: no cover
+    from numpy import nextafter
+
+try:
     from ._version import __version__
 except ImportError:  # pragma: no cover
     __version__ = 'Version unspecified'
@@ -254,22 +259,22 @@ class Tabulation(object):
 
         if t1.y[0] != 0 and t2.x[0] < t1.x[0]:
             # t1 leading is a step and t2 starts to the left, add a tiny ramp
-            eps_x = math.nextafter(t1.x[0], -math.inf)
+            eps_x = nextafter(t1.x[0], -math.inf)
             x1 = np.concatenate(([eps_x], x1))
             y1 = np.concatenate(([0.], y1))
         if t1.y[-1] != 0 and t2.x[-1] > t1.x[-1]:
             # t1 trailing is a step and t2 end to the right, add a tiny ramp
-            eps_x = math.nextafter(t1.x[-1], math.inf)
+            eps_x = nextafter(t1.x[-1], math.inf)
             x1 = np.concatenate((x1, [eps_x]))
             y1 = np.concatenate((y1, [0.]))
         if t2.y[0] != 0 and t1.x[0] < t2.x[0]:
             # t2 leading is a step and t1 starts to the left, add a tiny ramp
-            eps_x = math.nextafter(t2.x[0], -math.inf)
+            eps_x = nextafter(t2.x[0], -math.inf)
             x2 = np.concatenate(([eps_x], x2))
             y2 = np.concatenate(([0.], y2))
         if t2.y[-1] != 0 and t1.x[-1] > t2.x[-1]:
             # t2 trailing is a step and t1 end to the right, add a tiny ramp
-            eps_x = math.nextafter(t2.x[-1], math.inf)
+            eps_x = nextafter(t2.x[-1], math.inf)
             x2 = np.concatenate((x2, [eps_x]))
             y2 = np.concatenate((y2, [0.]))
 
@@ -686,8 +691,8 @@ class Tabulation(object):
         """Return the weighted center x coordinate of the Tabulation.
 
         Parameters:
-            dx (float, optional): The minimum, uniform step size to use when evaluating the
-                center position. If omitted, no resampling is performed.
+            dx (float, optional): The minimum, uniform step size to use when evaluating
+                the center position. If omitted, no resampling is performed.
 
         Returns:
             float: The x coordinate that corresponds to the weighted center of the
@@ -718,8 +723,8 @@ class Tabulation(object):
         This is the mean value of (y * (x - x_mean)**2)**(1/2).
 
         Parameters:
-            dx (float, optional): The minimum, uniform step size to use when evaluating the
-                center position. If omitted, no resampling is performed.
+            dx (float, optional): The minimum, uniform step size to use when evaluating
+                the center position. If omitted, no resampling is performed.
 
         Returns:
             float: The RMS width of the Tabulation.

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -107,6 +107,10 @@ class Tabulation(object):
 
         Returns:
             Tabulation: The current Tabulation object mutated with the new arrays.
+
+        Raises:
+            ValueError: If the x and/or y arrays do not have the proper dimensions,
+            size, or monotinicity.
         """
 
         x = np.asarray(x, dtype=np.double)
@@ -146,6 +150,9 @@ class Tabulation(object):
 
         Returns:
             Tabulation: The current Tabulation object mutated with the new array.
+
+        Raises:
+            ValueError: If the x and y arrays do not have the same size.
         """
 
         y = np.asarray(new_y, dtype=np.double)
@@ -282,7 +289,7 @@ class Tabulation(object):
             x1 = np.concatenate(([eps_x], x1))
             y1 = np.concatenate(([0.], y1))
         if t1.y[-1] != 0 and t2.x[-1] > t1.x[-1]:
-            # t1 trailing is a step and t2 end to the right, add a tiny ramp
+            # t1 trailing is a step and t2 ends to the right, add a tiny ramp
             eps_x = nextafter(t1.x[-1], math.inf)
             x1 = np.concatenate((x1, [eps_x]))
             y1 = np.concatenate((y1, [0.]))
@@ -292,7 +299,7 @@ class Tabulation(object):
             x2 = np.concatenate(([eps_x], x2))
             y2 = np.concatenate(([0.], y2))
         if t2.y[-1] != 0 and t1.x[-1] > t2.x[-1]:
-            # t2 trailing is a step and t1 end to the right, add a tiny ramp
+            # t2 trailing is a step and t1 ends to the right, add a tiny ramp
             eps_x = nextafter(t2.x[-1], math.inf)
             x2 = np.concatenate((x2, [eps_x]))
             y2 = np.concatenate((y2, [0.]))
@@ -341,8 +348,8 @@ class Tabulation(object):
             Tabulation: The new Tabulation.
 
         Raises:
-            ValueError: If the domains of the two Tabulations do not overlap.
-            ValueError: If the Tabulation can not be multiplied by the given value.
+            ValueError: If the domains of the two Tabulations do not overlap, or if the
+            Tabulation can not be multiplied by the given value.
 
         Notes:
             The new domain is the intersection of the domains of the current Tabulation
@@ -369,11 +376,11 @@ class Tabulation(object):
             other (float): Scale the current Tabulation's y-coordinates uniformly by
                 dividing by the given value.
 
-        Raises:
-            ValueError: If the Tabulation can not be multiplied by the given value.
-
         Returns:
             Tabulation: The new Tabulation.
+
+        Raises:
+            ValueError: If the Tabulation can not be multiplied by the given value.
         """
 
         if np.shape(other) == ():
@@ -391,8 +398,8 @@ class Tabulation(object):
             Tabulation: The new Tabulation.
 
         Raises:
-            ValueError: If the domains of the two Tabulations do not overlap.
-            ValueError: If the Tabulation can not be added to the given value.
+            ValueError: If the domains of the two Tabulations do not overlap, or if the
+            Tabulation can not be added to the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -420,8 +427,8 @@ class Tabulation(object):
             Tabulation: The new Tabulation.
 
         Raises:
-            ValueError: If the domains of the two Tabulations do not overlap.
-            ValueError: If the Tabulation can not be subtracted by the given value.
+            ValueError: If the domains of the two Tabulations do not overlap, or if the
+            Tabulation can not be subtracted by the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -451,8 +458,8 @@ class Tabulation(object):
             Tabulation: The current Tabulation mutated with the new values.
 
         Raises:
-            ValueError: If the domains of the two Tabulations do not overlap.
-            ValueError: If the Tabulation can not be multiplied by the given value.
+            ValueError: If the domains of the two Tabulations do not overlap, or if the
+            Tabulation can not be multiplied by the given value.
 
         Notes:
             The new domain is the intersection of the domains of the current Tabulation
@@ -480,11 +487,11 @@ class Tabulation(object):
             other (float): Scale the current Tabulation's y-coordinates uniformly by
                 dividing by the given value.
 
-        Raises:
-            ValueError: If the Tabulation can not be divided by the given value.
-
         Returns:
             Tabulation: The current Tabulation mutated with the new values.
+
+        Raises:
+            ValueError: If the Tabulation can not be divided by the given value.
         """
 
         if np.shape(other) == ():
@@ -502,8 +509,8 @@ class Tabulation(object):
             Tabulation: The current Tabulation mutated with the new values.
 
         Raises:
-            ValueError: If the domains of the two Tabulations do not overlap.
-            ValueError: If the Tabulation can not be added to the given value.
+            ValueError: If the domains of the two Tabulations do not overlap, or if the
+            Tabulation can not be added to the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -531,8 +538,8 @@ class Tabulation(object):
             Tabulation: The current Tabulation mutated with the new values.
 
         Raises:
-            ValueError: If the domains of the two Tabulations do not overlap.
-            ValueError: If the Tabulation can not be subtracted by the given value.
+            ValueError: If the domains of the two Tabulations do not overlap, or if the
+            Tabulation can not be subtracted by the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -650,6 +657,9 @@ class Tabulation(object):
         Returns:
             Tabulation: A new Tabulation equivalent to the current Tabulation but sampled
             only at the given x-coordinates.
+
+        Raises:
+            ValueError: If the x coordinates are not monotonic.
 
         Notes:
             If the leading or trailing X coordinate corresponds to a non-zero value, then
@@ -810,7 +820,14 @@ class Tabulation(object):
 
         Returns:
             float: The FWHM for the given fractional height.
+
+        Raises:
+            ValueError: If the Tabulation does not cross the fractional height exactly
+            twice, or if the fraction is outside the range 0 to 1.
         """
+
+        if not 0 <= fraction <= 1:
+            raise ValueError("fraction is outside the range 0-1")
 
         max = np.max(self.y)
         limits = self.locate(max * fraction)

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -1,45 +1,85 @@
-################################################################################
-# tabulation.py
-#
-# The Tabulation class represents a function by a sequence of linear
-# interpolations between points defined by arrays of x and y coordinates.
-#
-# Mark Showalter, PDS Rings Node, December 2011
-################################################################################
+##########################################################################################
+# tabulation/__init__.py
+##########################################################################################
+"""
+Tabulation class,
+PDS Ring-Moon Systems Node, SETI Institute
 
-from __future__ import division
+The Tabulation class represents a mathematical function by a sequence of linear
+interpolations between points defined by arrays of x and y coordinates. See the
+documentation for the Tabulation class for full details.
+"""
 
 import numpy as np
 from scipy.interpolate import interp1d
 
 try:
     from ._version import __version__
-except ImportError as err:
+except ImportError:
     __version__ = 'Version unspecified'
 
 
 class Tabulation(object):
-    """A class that represents a function by a sequence of linear interpolations
-    between points defined by arrays of x and y coordinates. The function is
-    treated as equal to zero outside the range of the x coordinates."""
+    """A class that represents a function by a sequence of linear interpolations.
+
+    The interpolations are defined between points defined by arrays of x and y
+    coordinates. The function is treated as equal to zero outside the range of the x
+    coordinates. However, if supplied, one leading and/or trailing zero is considered
+    significant because it anchors the interpolation at the beginning or end of the
+    domain. If there is no leading and/or trailing zero, the interpolation starts as a
+    step function at the first (or last) supplied value. For example::
+
+        >>> t = Tabulation([4, 6], [10, 10])
+        >>> t([ 1,   2,   3,   4,   5,   6,   7,   8,   9])
+        array([ 0.,  0.,  0., 10., 10., 10.,  0.,  0.,  0.])
+        >>> t.mean()
+        10.0
+
+        >>> t = Tabulation([2, 4, 6], [0, 10, 10])
+        >>> t([ 1,   2,   3,   4,   5,   6,   7,   8,   9])
+        array([ 0.,  0.,  5., 10., 10., 10.,  0.,  0.,  0.])
+        >>> t.mean()
+        7.5
+
+    By default it is assumed that the function never has leading or trailing zeros beyond
+    the single zero necessary to anchor the interpolation, and the Tabulation object will
+    automatically trim any additional leading and/or trailing regions of the domain that
+    have purely zero values after many operations. This is done to improve space and time
+    efficiency.
+
+    However, while reasonable for most applications, there are times where it is important
+    to have the domain include some amount of zero values, as trimming affects
+    computations such as `mean` and `pivot_mean`. In these cases, the best workaround is
+    to supply extremely small but non-zero values for those regions.
+    """
 
     def __init__(self, x, y):
-        """Constructor for a Tabulation object.
+        """
+        Constructor for a Tabulation object.
 
-        Input:
-            x       a 1-D array of x-coordinates, which must be monotonic.
-            y       a 1-D array of y-values, given in the same order as the
-                    x-coordinates.
+        Parameters:
+            x (array-like): A 1-D array of x-coordinates, which must be monotonic (either
+                increasing or decreasing).
+            y (array-like): A 1-D array of y-values, given in the same order as the
+                x-coordinates.
         """
 
-        ignore = self._update(x,y)
+        self._update(x, y)
 
-########################################
-# Private methods
-########################################
+    ########################################
+    # Private methods
+    ########################################
 
     def _update(self, x, y):
-        """Updates a tabulation in place with new x and y arrays."""
+        """Update a Tabulation in place with new x and y arrays.
+
+        Parameters:
+            x (array-like): The new 1-D array of x-coordinates.
+            y (array-like): The new 1-D array of y-coordinates.
+
+        Returns:
+            Tabulation: The current Tabulation object mutated with the new arrays.
+        """
 
         x = np.asarray(x, dtype=np.double)
         y = np.asarray(y, dtype=np.double)
@@ -64,7 +104,14 @@ class Tabulation(object):
         return self
 
     def _update_y(self, new_y):
-        """Updates a tabulation in place with a new y array."""
+        """Update a Tabulation in place with a new y array.
+
+        Parameters:
+            new_y (array-like): The new 1-D array of y-coordinates.
+
+        Returns:
+            Tabulation: The current Tabulation object mutated with the new array.
+        """
 
         y = np.asarray(new_y, dtype=np.double)
 
@@ -76,42 +123,48 @@ class Tabulation(object):
         return self
 
     def _trim(self):
-        """Updates the given Tabulation by deleting leading and trailing regions
-        of the domain that contain nothing but zeros. This is never strictly
-        necessary but can improve efficiency and reduce memory requirements. It
-        can be useful because many filter bandpass functions contains strings of
-        zeros at one end or the other.
+        """Update a Tabulation in place by deleting leading/trailing zero-valued regions.
 
-        NOTE that this function operates in-place, returning the same
-        Tabulation object.
+        Returns:
+            Tabulation: The current Tabulation object mutated with the unused regions
+            removed.
+
+        Notes:
+            This will always create a copy of the x and y coordinates.
         """
 
+        def _trim1(x, y):
+            """Strip away the leading end of an (x,y) array pair."""
+            # Define a mask at the low end
+            mask = np.cumsum(y != 0.) != 0
+
+            # Shift left by one to keep last zero
+            mask[:-1] = mask[1:]
+
+            return (x[mask], y[mask])
+
         # Trim the trailing end
-        (new_x, new_y) = Tabulation._trim1(self.x[::-1], self.y[::-1])
+        (new_x, new_y) = _trim1(self.x[::-1], self.y[::-1])
 
         # Trim the leading end
-        (new_x, new_y) = Tabulation._trim1(new_x[::-1], new_y[::-1])
+        (new_x, new_y) = _trim1(new_x[::-1], new_y[::-1])
 
         return self._update(new_x, new_y)
 
     @staticmethod
-    def _trim1(x,y):
-        """Private procedure used by trim() to strip away the leading end of
-        an (x,y) array pair.
-        """
-
-        # Define a mask at the low end
-        mask = np.cumsum(y != 0.) != 0
-
-        # Shift left by one to keep last zero
-        mask[:-1] = mask[1:]
-
-        return (x[mask], y[mask])
-
-    @staticmethod
     def _xmerge(x1, x2):
-        """Returns a new array of x-values containing the union of x-values
-        found in each of the given arrays.
+        """Return the union of x-coordinates found in each of the given arrays.
+
+        Parameters:
+            x1 (array-like): The first array of x-coordinates.
+            x2 (array-like): The second array of x-coordinates.
+
+        Returns:
+            np.array: The merged array of x-coordinates.
+
+        Notes:
+            The domains must have some overlap. The resulting domain will range from the
+            minimum of the two arrays to the maximum of the two arrays.
         """
 
         # Confirm overlap
@@ -126,21 +179,41 @@ class Tabulation(object):
         return sorted[mask]
 
     @staticmethod
-    def _xoverlap(x1,x2):
-        """Returns a new array of x-values containing the union of x-values from
-        each of the given arrays that fall within the intersection of the two
-        domains.
+    def _xoverlap(x1, x2):
+        """Return the union of x-coords that fall within the intersection of the domains.
+
+        Parameters:
+            x1 (array-like): The first array of x-coordinates.
+            x2 (array-like): The second array of x-coordinates.
+
+        Returns:
+            np.array: The merged array of x-coordinates, limited to those values that
+            fall within the intersection of the domains of the two arrays.
+
+        Notes:
+            The domains must have some overlap. The resulting domain will include only
+            the region where the two arrays intersect.
         """
 
-        new_x = Tabulation._xmerge(x1,x2)
-        mask = (new_x >= max(x1[0],x2[0])) & (new_x <= min(x1[-1],x2[-1]))
+        new_x = Tabulation._xmerge(x1, x2)
+        mask = (new_x >= max(x1[0], x2[0])) & (new_x <= min(x1[-1], x2[-1]))
         return new_x[mask]
 
-########################################
-# Standard operators
-########################################
+    ########################################
+    # Standard operators
+    ########################################
 
     def __call__(self, x):
+        """Return the interpolated value corresponding to an x-coordinate.
+
+        Parameters:
+            x (float or array-like): The x-coordinate(s) at which to evaluate the
+                Tabulation.
+
+        Returns:
+            float or array-like: The value(s) of the interpolated y-coordinates at the
+            given x(s).
+        """
         # Fill in the 1-D interpolation if necessary
         if self.func is None:
             self.func = interp1d(self.x, self.y, kind="linear",
@@ -152,12 +225,24 @@ class Tabulation(object):
         return float(self.func(x))
 
     def __mul__(self, other):
+        """Multiply two Tabulations returning a new Tabulation.
 
-        # Multiplication of two Tabulations
-        # Note: the new domain is the intersection of the given domains
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, multiply it with the
+                current Tabulation at each interpolation point. If a float is given,
+                scale the current Tabulation's y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The new Tabulation.
+
+        Notes:
+            The new domain is the intersection of the domains of the current Tabulation
+            and the given Tabulation.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xoverlap(self.x, other.x)
-            return Tabulation(new_x, self(new_x) * other(new_x))._trim()
+            return Tabulation(new_x, self(new_x) * other(new_x))
 
         # Otherwise just scale the y-values
         elif np.shape(other) == ():
@@ -166,12 +251,24 @@ class Tabulation(object):
         raise ValueError("Cannot multiply Tabulation by given value")
 
     def __truediv__(self, other):
+        """Divide two Tabulations returning a new Tabulation.
 
-        # Division of two Tabulations
-        # Note: the new domain is the intersection of the given domains
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, divide the current
+                Tabulation by this Tabulation at each interpolation point. If a float is
+                given, scale the current Tabulation's y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The new Tabulation.
+
+        Notes:
+            The new domain is the intersection of the domains of the current Tabulation
+            and the given Tabulation.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xoverlap(self.x, other.x)
-            return Tabulation(new_x, self(new_x) / other(new_x))._trim()
+            return Tabulation(new_x, self(new_x) / other(new_x))
 
         # Otherwise just scale the y-values
         elif np.shape(other) == ():
@@ -180,10 +277,24 @@ class Tabulation(object):
         raise ValueError("Cannot divide Tabulation by given value")
 
     def __add__(self, other):
+        """Add two Tabulations returning a new Tabulation.
 
-        # Addition of two Tabulations
-        # Note: the new domain is the union of the given domains
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, add it to the current
+                Tabulation at each interpolation point. If a float is given, add it to
+                each of the current Tabulation's y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The new Tabulation.
+
+        Notes:
+            The new domain is the union of the domains of the current Tabulation and
+            the given Tabulation.
+
+            A constant added to a Tabulation will still return zero outside the domain.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xmerge(self.x, other.x)
             return Tabulation(new_x, self(new_x) + other(new_x))
 
@@ -193,14 +304,26 @@ class Tabulation(object):
 
         raise ValueError("Cannot add Tabulation by given value")
 
-        # Note that a constant added to a Tabulation will still return zero
-        # outside the domain.
-
     def __sub__(self, other):
+        """Subtract two Tabulations returning a new Tabulation.
 
-        # Subtraction of two Tabulations
-        # Note: the new domain is the union of the given domains
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, subtract it from the
+                current Tabulation at each interpolation point. If a float is given,
+                subtract it from each of the current Tabulation's y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The new Tabulation.
+
+        Notes:
+            The new domain is the union of the domains of the current Tabulation and
+            the given Tabulation.
+
+            A constant subtracted from a Tabulation will still return zero outside the
+            domain.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xmerge(self.x, other.x)
             return Tabulation(new_x, self(new_x) - other(new_x))
 
@@ -210,13 +333,22 @@ class Tabulation(object):
 
         raise ValueError("Cannot subtract Tabulation by given value")
 
-        # Note that a constant subtracted from a Tabulation will still return
-        # zero outside the domain.
-
     def __imul__(self, other):
+        """Multiply two Tabulations in place.
 
-        # In-place multiplication of two Tabulations
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, multiply it with the
+                current Tabulation at each interpolation point. If a float is given,
+                scale the y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The current Tabulation mutated with the new values.
+
+        Notes:
+            The new domain is the intersection of the given domains.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xoverlap(self.x, other.x)
             return self._update(new_x, self(new_x) * other(new_x))._trim()
 
@@ -227,9 +359,21 @@ class Tabulation(object):
         raise ValueError("Cannot multiply Tabulation in-place by given value")
 
     def __itruediv__(self, other):
+        """Divide two Tabulations in place.
 
-        # In-place division of two Tabulations
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, divide the current
+                Tabulation by this Tabulation at each interpolation point. If a float is
+                given, scale the y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The current Tabulation mutated with the new values.
+
+        Notes:
+            The new domain is the intersection of the given domains.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xoverlap(self.x, other.x)
             return self._update(new_x, self(new_x) / other(new_x))._trim()
 
@@ -240,9 +384,23 @@ class Tabulation(object):
         raise ValueError("Cannot divide Tabulation in-place by given value")
 
     def __iadd__(self, other):
+        """Add two Tabulations in place.
 
-        # In-place addition of two Tabulations
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, add it to the current
+                Tabulation at each interpolation point. If a float is given, add it to
+                each of the y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The current Tabulation mutated with the new values.
+
+        Notes:
+            The new domain is the union of the given domains.
+
+            A constant added to a Tabulation will still return zero outside the domain.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xmerge(self.x, other.x)
             return self._update(new_x, self(new_x) + other(new_x))
 
@@ -250,15 +408,27 @@ class Tabulation(object):
         elif np.shape(other) == ():
             return self._update_y(self.y + other)
 
-        # Note that a constant added to a Tabulation will still return zero
-        # outside the domain.
-
         raise ValueError("Cannot add Tabulation in-place by given value")
 
     def __isub__(self, other):
+        """Subtract two Tabulations in place.
 
-        # In-place subtraction of two Tabulations
-        if type(other) == type(self):
+        Parameters:
+            other (Tabulation or float): If a Tabulation is given, subtract it from the
+                current Tabulation at each interpolation point. If a float is given,
+                subtract it from each of the y-coordinates uniformly.
+
+        Returns:
+            Tabulation: The current Tabulation mutated with the new values.
+
+        Notes:
+            The new domain is the union of the given domains.
+
+            A constant subtracted from a Tabulation will still return zero outside the
+            domain.
+        """
+
+        if type(other) is type(self):
             new_x = Tabulation._xmerge(self.x, other.x)
             return self._update(new_x, self(new_x) - other(new_x))
 
@@ -266,8 +436,6 @@ class Tabulation(object):
         elif np.shape(other) == ():
             return self._update_y(self.y - other)
 
-        # Note that a constant subtracted from a Tabulation will still return
-        # zero outside the domain.
         raise ValueError("Cannot subtract Tabulation in-place by given value")
 
 ########################################
@@ -275,8 +443,17 @@ class Tabulation(object):
 ########################################
 
     def trim(self):
-        """Returns a new Tabulation (shallow copy) in which the zero-valued
-        leading and trailing regions of the domain have been removed."""
+        """Return a new Tabulation where zero-valued leading/trailing regions are removed.
+
+        Returns:
+            Tabulation: A copy of the current Tabulation object with any zero-valued
+            leading or trailing regions removed. A single leading or trailing zero
+            will be left to anchor the interpolation as necessary.
+
+        Notes:
+            Calling this function is not generally necessary, as it is performed
+            automatically by various methods.
+        """
 
         # Save the original arrays
         x = self.x
@@ -293,24 +470,42 @@ class Tabulation(object):
         return result
 
     def domain(self):
-        """Returns a tuple containing the range of x-values over which the
-        function is nonzero.
+        """Return the range of x-coordinates for which values have been provided.
+
+        Returns:
+            tuple: A tuple (xmin, xmax).
         """
 
-        return (self.x[0], self.x[-1])
+        return (float(self.x[0]), float(self.x[-1]))
 
     def clip(self, xmin, xmax):
-        """Returns a tuple in which the domain has been redefined as
-        (xmin,xmax).
+        """Return a Tabulation where the domain is (xmin, xmax).
+
+        Parameters:
+            xmin (float): The minimum value of the new x-coordinates.
+            xmax (float): The maximum value of the new x-coordinates.
+
+        Returns:
+            Tabulation: The new Tabulation, identical to the current Tabulation except
+            that the x domain is now (xmin, xmax). If either x coordinate is beyond
+            the range of the current domain, zeros are assumed for the y values.
         """
 
-        new_x = Tabulation._xmerge(self.x, np.array((xmin,xmax)))
+        new_x = Tabulation._xmerge(self.x, np.array((xmin, xmax)))
         mask = (new_x >= xmin) & (new_x <= xmax)
         return self.resample(new_x[mask])
 
     def locate(self, yvalue):
-        """Returns a list of the x-values where the Tabulation has the given
-        value of y. Note that the exact ends of the domain are not checked."""
+        """Return x-coordinates where the Tabulation has the given value of y.
+
+        Note that the exact ends of the domain are not checked.
+
+        Parameters:
+            yvalue (float): The value to look for.
+
+        Returns:
+            list: A list of x-coordinates where the Tabulation equals `yvalue`.
+        """
 
         signs = np.sign(self.y - yvalue)
         mask = (signs[:-1] * signs[1:]) < 0.
@@ -323,23 +518,27 @@ class Tabulation(object):
 
         xarray = xlo + (yvalue - ylo)/(yhi - ylo) * (xhi - xlo)
         xlist = list(xarray) + list(self.x[signs == 0])
+        xlist = [float(x) for x in xlist]
         xlist.sort()
 
         return xlist
 
     def integral(self):
-        """Returns the integral of [y dx].
+        """Return the integral of [y dx].
+
+        Returns:
+            float: The integral.
         """
 
-        # Make an array consisting of the midpoints between the x-values
+        # Make an array consisting of the midpoints between the x-coordinates
         # Begin with an array holding one extra element
         dx = np.empty(self.x.size + 1)
 
         dx[1:] = self.x         # Load the array shifted right
-        dx[0]  = self.x[0]      # Replicate the endpoint
+        dx[0] = self.x[0]       # Replicate the endpoint
 
         dx[:-1] += self.x       # Add the array shifted left
-        dx[-1]  += self.x[-1]
+        dx[-1] += self.x[-1]
 
         # dx[] is now actually 2x the value at each midpoint.
 
@@ -350,10 +549,18 @@ class Tabulation(object):
         # element is to be ignored.
 
         # The integral is now the sum of the products y * dx
-        return -0.5 * np.sum(self.y * dx[:-1])
+        return float(-0.5 * np.sum(self.y * dx[:-1]))
 
     def resample(self, new_x):
-        """Re-samples a tabulation at a given list of x-values."""
+        """Return a new Tabulation re-sampled at a given list of x-coordinates.
+
+        Parameters:
+            new_x (array-like): The new x-coordinates.
+
+        Returns:
+            Tabulation: A new Tabulation equivalent to the current Tabulation but
+            sampled only at the given x-coordinates.
+        """
 
         if new_x is None:
             # If new_x is None, return a copy of the current tabulation
@@ -362,84 +569,110 @@ class Tabulation(object):
         return Tabulation(new_x, self(new_x))
 
     def subsample(self, new_x):
-        """Resamples a tabulation at the given list of x-values, while at the
-        same time retaining all original x-values."""
+        """Return a new Tabulation re-sampled at a list of x-coords plus existing ones.
+
+        Parameters:
+            new_x (array-like): The new x-coordinates.
+
+        Returns:
+            Tabulation: A new Tabulation equivalent to the current Tabulation but
+            sampled only at the given x-coordinates.
+        """
 
         new_x = Tabulation._xmerge(new_x, self.x)
         return Tabulation(new_x, self(new_x))
 
-    def mean(self, dx=None):
-        """Returns the mean value of the tabulation. If specified, dx is the
-        minimum step permitted along the x-axis during integration."""
+    def mean(self):
+        """Return the mean value of the Tabulation.
 
-        trimmed = self.trim()
+        Returns:
+            float: The mean across the domain, ignoring leading and trailing zero regions.
+        """
 
-        if dx is None:
-            resampled = Tabulation(self.x, self.y.copy())
-                                            # y cannot be a shallow copy...
-        else:
-            (x0,x1) = trimmed.domain()
-            new_x = np.arange(x0 + dx, x1, dx).astype("float")
-            resampled = trimmed.subsample(new_x)
+        self._trim()
+        (x0, x1) = self.domain()
 
-        integ0 = resampled.integral()
+        integ = self.integral()
 
-        resampled.y *= resampled.x          # ...because we change y in-place
-        integ1 = resampled.integral()
+        return float(integ / (x1-x0))
 
-        return integ1/integ0
+    # def bandwidth_rms(self):
+    #     """Return the root-mean-square width of the Tabulation.
 
-    def bandwidth_rms(self, dx=None):
-        """Returns the root-mean-square width of the tabulation. This is the
-        mean value of (y * (x - x_mean)**2)**(1/2). If specified, dx is the
-        minimum step permitted along the x-axis during integration."""
+    #     This is the mean value of (y * (x - x_mean)**2)**(1/2).
 
-        trimmed = self.trim()
+    #     Returns:
+    #         float: The RMS width of the Tabulation.
+    #     """
 
-        if dx is None:
-            resampled = Tabulation(self.x, self.y.copy())
-                                            # y cannot be a shallow copy...
-        else:
-            (x0,x1) = trimmed.domain()
-            new_x = np.arange(x0 + dx, x1, dx).astype("float")
-            resampled = trimmed.subsample(new_x)
+    #     self._trim()
+    #     (x0, x1) = self.domain()
+    #     x_mean = (x0 + x1) / 2
 
-        integ0 = resampled.integral()
+    #     integ0 = resampled.integral()
 
-        resampled.y *= resampled.x          # ...because we change y in-place
-        integ1 = resampled.integral()
+    #     resampled.y *= resampled.x          # ...because we change y in-place
+    #     integ1 = resampled.integral()
 
-        resampled.y *= resampled.x          # ...twice!
-        integ2 = resampled.integral()
+    #     resampled.y *= resampled.x          # ...twice!
+    #     integ2 = resampled.integral()
 
-        return np.sqrt(((integ2*integ0 - integ1**2) / integ0**2))
+    #     return float(np.sqrt(((integ2*integ0 - integ1**2) / integ0**2)))
 
-    def pivot_mean(self, precision=0.01):
-        """Returns the "pivot" mean value of the tabulation. The pivot value is
-        the mean value of y(x) d(log(x)). Note all x must be positive."""
+    # def pivot_mean(self, precision=0.01):
+    #     """Return the "pivot" mean value of the tabulation.
 
-        trimmed = self.trim()
-        (x0,x1) = trimmed.domain()
+    #     The pivot value is the mean value of y(x) d(log(x)).
+    #     Note all x must be positive.
 
-        log_x0 = np.log(x0)
-        log_x1 = np.log(x1)
-        log_dx = np.log(1. + precision)
+    #     Parameters:
+    #         precision (float, optional): The step size at which to resample the
+    #             Tabulation.
 
-        new_x = np.exp(np.arange(log_x0, log_x1 + log_dx, log_dx))
+    #     Returns:
+    #         float: The pivot mean of the Tabulation.
+    #     """
 
-        resampled = trimmed.subsample(new_x)
-        integ1 = resampled.integral()
+    #     self._trim()
+    #     (x0, x1) = self.domain()
 
-        resampled.y /= resampled.x
-        integ0 = resampled.integral()
+    #     log_x0 = np.log(x0)
+    #     log_x1 = np.log(x1)
+    #     log_dx = np.log(1. + precision)
 
-        return integ1/integ0
+    #     new_x = np.exp(np.arange(log_x0, log_x1 + log_dx, log_dx))
+
+    #     resampled = self.subsample(new_x)
+    #     integ = resampled.integral()
+
+    #     return float(integ / (log_x1 - log_x0))
 
     def fwhm(self, fraction=0.5):
+        """Return the full-width-half-maximum of the Tabulation.
+
+        Parameters:
+            fraction (float, option): The fractional height at which to perform the
+                measurement. 0.5 corresponds to "half" maximum for a normal FWHM.
+
+        Returns:
+            float: The FWHM for the given fractional height.
+        """
+
         max = np.max(self.y)
         limits = self.locate(max * fraction)
-        assert len(limits) == 2
-        return limits[1] - limits[0]
+        if len(limits) != 2:
+            raise ValueError("Tabulation does not cross fractional height twice")
+        return float(limits[1] - limits[0])
 
     def square_width(self):
-        return self.integral() / np.max(self.y)
+        """Return the square width of the Tabulation.
+
+        The square width is the width of a rectangular function with y value equal
+        to the maximum of the original function and having the same area as the original
+        function.
+
+        Returns:
+            float: The square width of the Tabulation.
+        """
+
+        return float(self.integral() / np.max(self.y))

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -15,7 +15,7 @@ from scipy.interpolate import interp1d
 
 try:
     from ._version import __version__
-except ImportError:
+except ImportError:  # pragma: no cover
     __version__ = 'Version unspecified'
 
 

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -6,8 +6,10 @@ Tabulation class,
 PDS Ring-Moon Systems Node, SETI Institute
 
 The Tabulation class represents a mathematical function by a sequence of linear
-interpolations between points defined by arrays of x and y coordinates. See the
-documentation for the Tabulation class for full details.
+interpolations between points defined by arrays of x and y coordinates. Although optimized
+to model filter bandpasses and spectral flux, the class is sufficiently general to be used
+in a wide range of applications. See the documentation for the Tabulation class for full
+details.
 """
 
 import math
@@ -25,7 +27,9 @@ class Tabulation(object):
 
     The interpolations are defined between points defined by arrays of x and y
     coordinates. The function is treated as equal to zero outside the range of the x
-    coordinates, with a step at the provided leading and trailing x coordinates.
+    coordinates, with a step at the provided leading and trailing x coordinates. Although
+    optimized to model filter bandpasses and spectral flux, the class is sufficiently
+    general to be used in a wide range of applications.
 
     In general, zero values (either supplied or computed) at either the leading or
     trailing ends are removed. However, if explicitly supplied, one leading and/or
@@ -176,6 +180,9 @@ class Tabulation(object):
         Returns:
             np.array: The merged array of x-coordinates.
 
+        Raises:
+            ValueError: If the domains do not overlap.
+
         Notes:
             The domains must have some overlap. The resulting domain will range from the
             minimum of the two arrays to the maximum of the two arrays.
@@ -183,7 +190,7 @@ class Tabulation(object):
 
         # Confirm overlap
         if x1[0] > x2[-1] or x2[0] > x1[-1]:
-            raise ValueError("domains do not overlap")
+            raise ValueError("Domains do not overlap")
 
         # Merge and sort
         sorted = np.sort(np.hstack((x1, x2)))
@@ -203,6 +210,9 @@ class Tabulation(object):
         Returns:
             np.array: The merged array of x-coordinates, limited to those values that
             fall within the intersection of the domains of the two arrays.
+
+        Raises:
+            ValueError: If the domains do not overlap.
 
         Notes:
             The domains must have some overlap. The resulting domain will include only
@@ -284,6 +294,10 @@ class Tabulation(object):
         Returns:
             Tabulation: The new Tabulation.
 
+        Raises:
+            ValueError: If the domains of the two Tabulations do not overlap.
+            ValueError: If the Tabulation can not be multiplied by the given value.
+
         Notes:
             The new domain is the intersection of the domains of the current Tabulation
             and the given Tabulation. Because the resulting Tabulation is only computed
@@ -309,6 +323,9 @@ class Tabulation(object):
             other (float): Scale the current Tabulation's y-coordinates uniformly by
                 dividing by the given value.
 
+        Raises:
+            ValueError: If the Tabulation can not be multiplied by the given value.
+
         Returns:
             Tabulation: The new Tabulation.
         """
@@ -326,6 +343,10 @@ class Tabulation(object):
 
         Returns:
             Tabulation: The new Tabulation.
+
+        Raises:
+            ValueError: If the domains of the two Tabulations do not overlap.
+            ValueError: If the Tabulation can not be added to the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -351,6 +372,10 @@ class Tabulation(object):
 
         Returns:
             Tabulation: The new Tabulation.
+
+        Raises:
+            ValueError: If the domains of the two Tabulations do not overlap.
+            ValueError: If the Tabulation can not be subtracted by the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -379,6 +404,10 @@ class Tabulation(object):
         Returns:
             Tabulation: The current Tabulation mutated with the new values.
 
+        Raises:
+            ValueError: If the domains of the two Tabulations do not overlap.
+            ValueError: If the Tabulation can not be multiplied by the given value.
+
         Notes:
             The new domain is the intersection of the domains of the current Tabulation
             and the given Tabulation. Because the resulting Tabulation is only computed
@@ -405,6 +434,9 @@ class Tabulation(object):
             other (float): Scale the current Tabulation's y-coordinates uniformly by
                 dividing by the given value.
 
+        Raises:
+            ValueError: If the Tabulation can not be divided by the given value.
+
         Returns:
             Tabulation: The current Tabulation mutated with the new values.
         """
@@ -422,6 +454,10 @@ class Tabulation(object):
 
         Returns:
             Tabulation: The current Tabulation mutated with the new values.
+
+        Raises:
+            ValueError: If the domains of the two Tabulations do not overlap.
+            ValueError: If the Tabulation can not be added to the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -447,6 +483,10 @@ class Tabulation(object):
 
         Returns:
             Tabulation: The current Tabulation mutated with the new values.
+
+        Raises:
+            ValueError: If the domains of the two Tabulations do not overlap.
+            ValueError: If the Tabulation can not be subtracted by the given value.
 
         Notes:
             The new domain is the union of the domains of the current Tabulation and the
@@ -488,6 +528,10 @@ class Tabulation(object):
             Tabulation: The new Tabulation, identical to the current Tabulation except
             that the x domain is now (xmin, xmax). If either x coordinate is beyond
             the range of the current domain, it is set to the current edge of the
+            domain.
+
+        Raises:
+            ValueError: If the clip domain does not overlap with the Tabulation
             domain.
         """
 
@@ -590,30 +634,6 @@ class Tabulation(object):
 
         return Tabulation(new_x, self(new_x))
 
-
-        # our_x = self.x
-        # our_y = self.y
-
-        # # If we are resampling before the leading edge of the domain, and we have a
-        # # step function, then insert a fake x-coordinate to maintain the step appearance.
-        # if new_x[0] < our_x[0] and our_y[0] != 0:
-        #     eps_x = our_x[0]-.001 # math.nextafter(our_x[0], -math.inf)  # Epsilon lower
-        #     our_x = np.insert(our_x, 0, eps_x)
-        #     our_y = np.insert(our_y, 0, 0.)
-        #     print(our_x)
-        #     print(our_y)
-
-        # # If we are resampling after the traliing edge of the domain, and we have a
-        # # step function, then insert a fake x-coordinate to maintain the step appearance.
-        # if new_x[-1] > our_x[-1] and our_y[-1] != 0:
-        #     eps_x = math.nextafter(our_x[-1], math.inf)  # Epsilon higher
-        #     loc = np.where(new_x > our_x[-1])[0][0]
-        #     our_x = np.insert(our_x, loc+1, eps_x)
-        #     our_y = np.insert(our_y, loc+1, 0.)
-
-        # our_tabulation = self
-        # if our_x is not self.x:
-        #     our_tabulation = Tabulation(our_x, our_y)
     def subsample(self, new_x):
         """Return a new Tabulation re-sampled at a list of x-coords plus existing ones.
 
@@ -640,70 +660,100 @@ class Tabulation(object):
         new_x = Tabulation._xmerge(new_x, self.x)
         return Tabulation(new_x, self(new_x))
 
-    def mean(self):
-        """Return the mean value of the Tabulation.
+    def x_mean(self, dx=None):
+        """Return the weighted center x coordinate of the Tabulation.
+
+        Parameters:
+            dx (float, optional): The minimum, uniform step size to use when evaluating the
+                center position. If omitted, no resampling is performed.
 
         Returns:
-            float: The mean across the domain, ignoring leading and trailing zero regions.
+            float: The x coordinate that corresponds to the weighted center of the
+                function.
+        """
+
+        self._trim()
+
+        if dx is None:
+            # y cannot be a shallow copy...
+            resampled = Tabulation(self.x, self.y.copy())
+        else:
+            (x0, x1) = self.domain()
+            new_x = np.arange(x0 + dx, x1, dx).astype("float")
+            resampled = self.subsample(new_x)
+
+        integ0 = resampled.integral()
+
+        # ...because we change y in-place
+        resampled.y *= resampled.x
+        integ1 = resampled.integral()
+
+        return integ1/integ0
+
+    def bandwidth_rms(self, dx=None):
+        """Return the root-mean-square width of the Tabulation.
+
+        This is the mean value of (y * (x - x_mean)**2)**(1/2).
+
+        Parameters:
+            dx (float, optional): The minimum, uniform step size to use when evaluating the
+                center position. If omitted, no resampling is performed.
+
+        Returns:
+            float: The RMS width of the Tabulation.
+        """
+
+        self._trim()
+
+        if dx is None:
+            # y cannot be a shallow copy...
+            resampled = Tabulation(self.x, self.y.copy())
+        else:
+            (x0, x1) = self.domain()
+            new_x = np.arange(x0 + dx, x1, dx).astype("float")
+            resampled = self.subsample(new_x)
+
+        integ0 = resampled.integral()
+
+        # ...because we change y in-place
+        resampled.y *= resampled.x
+        integ1 = resampled.integral()
+
+        resampled.y *= resampled.x          # ...twice!
+        integ2 = resampled.integral()
+
+        return np.sqrt(((integ2*integ0 - integ1**2) / integ0**2))
+
+    def pivot_mean(self, precision=0.01):
+        """Return the "pivot" mean value of the tabulation.
+
+        The pivot value is the mean value of y(x) d(log(x)).
+        Note all x must be positive.
+
+        Parameters:
+            precision (float, optional): The step size at which to resample the
+                Tabulation.
+
+        Returns:
+            float: The pivot mean of the Tabulation.
         """
 
         self._trim()
         (x0, x1) = self.domain()
 
-        integ = self.integral()
+        log_x0 = np.log(x0)
+        log_x1 = np.log(x1)
+        log_dx = np.log(1. + precision)
 
-        return float(integ / (x1-x0))
+        new_x = np.exp(np.arange(log_x0, log_x1 + log_dx, log_dx))
 
-    # def bandwidth_rms(self):
-    #     """Return the root-mean-square width of the Tabulation.
+        resampled = self.subsample(new_x)
+        integ1 = resampled.integral()
 
-    #     This is the mean value of (y * (x - x_mean)**2)**(1/2).
+        resampled.y /= resampled.x
+        integ0 = resampled.integral()
 
-    #     Returns:
-    #         float: The RMS width of the Tabulation.
-    #     """
-
-    #     self._trim()
-    #     (x0, x1) = self.domain()
-    #     x_mean = (x0 + x1) / 2
-
-    #     integ0 = resampled.integral()
-
-    #     resampled.y *= resampled.x          # ...because we change y in-place
-    #     integ1 = resampled.integral()
-
-    #     resampled.y *= resampled.x          # ...twice!
-    #     integ2 = resampled.integral()
-
-    #     return float(np.sqrt(((integ2*integ0 - integ1**2) / integ0**2)))
-
-    # def pivot_mean(self, precision=0.01):
-    #     """Return the "pivot" mean value of the tabulation.
-
-    #     The pivot value is the mean value of y(x) d(log(x)).
-    #     Note all x must be positive.
-
-    #     Parameters:
-    #         precision (float, optional): The step size at which to resample the
-    #             Tabulation.
-
-    #     Returns:
-    #         float: The pivot mean of the Tabulation.
-    #     """
-
-    #     self._trim()
-    #     (x0, x1) = self.domain()
-
-    #     log_x0 = np.log(x0)
-    #     log_x1 = np.log(x1)
-    #     log_dx = np.log(1. + precision)
-
-    #     new_x = np.exp(np.arange(log_x0, log_x1 + log_dx, log_dx))
-
-    #     resampled = self.subsample(new_x)
-    #     integ = resampled.integral()
-
-    #     return float(integ / (log_x1 - log_x0))
+        return integ1/integ0
 
     def fwhm(self, fraction=0.5):
         """Return the full-width-half-maximum of the Tabulation.

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -137,8 +137,7 @@ class Tabulation(object):
         return self
 
     def _trim(self):
-        """
-        Update a Tabulation in place by deleting leading/trailing zero-valued regions.
+        """Update a Tabulation in place by deleting leading/trailing zero-valued regions.
 
         Notes:
             This will create a copy of the x and y coordinates if trimming is necessary,
@@ -225,6 +224,29 @@ class Tabulation(object):
 
     @staticmethod
     def _add_ramps_as_necessary(t1, t2):
+        """Create new Tabulations as necessary to provide leading/trailing ramps.
+
+        Given two Tabulations, either of which might have a "step" on the leading or
+        trailing edge, this function looks at the overlap and adds a microstep if
+        necessary to continue to have a step after the Tabulation domains are merged.
+
+        For example, if t1 has x=(5, 7) and y=(1, 1), it has a step at 5 and another step
+        at 7. If t2 has x=(4, 5, 6, 7) and y=(0, 1, 1, 0), it has a ramp from 4 to 5 and
+        a ramp at 6 to 7. If we try to perform a mathematical operation that combines
+        these two Tabulations in some way, t1's step will be changed, incorrectly, to
+        a ramp unless a step is forced. We force a step by adding x coordinates at
+        the smallest possible increments before or after the step edges, essentially
+        creating an infinitesimally-wide ramp. In this case we would create a new
+        t1 where x=(5-eps, 5, 7) and y=(0, 1, 1).
+
+        Parameters:
+            t1 (Tabulation): The first Tabulation
+            t2 (Tabulation): The second Tabulation
+
+        Returns:
+            Tabulation, Tabulation: The new Tabulations, if needed, or the original
+            Tabulations if not.
+        """
         x1 = t1.x
         y1 = t1.y
         x2 = t2.x
@@ -732,7 +754,7 @@ class Tabulation(object):
 
         Parameters:
             precision (float, optional): The step size at which to resample the
-                Tabulation.
+                Tabulation in log space.
 
         Returns:
             float: The pivot mean of the Tabulation.

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -418,7 +418,7 @@ class Test_Tabulation(unittest.TestCase):
         self.assertTrue(np.abs(boxcar.bandwidth_rms() - 5.) < 1e-7)
         self.assertTrue(np.abs(boxcar.bandwidth_rms(0.001) - 5. / np.sqrt(3.)) < 1e-7)
 
-        boxcar = Tabulation((10000, 10010),(1, 1))
+        boxcar = Tabulation((10000, 10010), (1, 1))
         self.assertEqual(boxcar.x_mean(), 10005.)
 
         # PIVOT_MEAN

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -22,7 +22,7 @@ class Test_Tabulation(unittest.TestCase):
         # xr = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         # yr = [0, 0, 0, 1, 2, 6, 1, 0, 0]
         xr = [-1., 0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.]
-        yr = [0., 0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 0., 0.]
+        yr = [0.,  0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.,  0.,  0.]
 
         # Step-style edges
         xs = [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]
@@ -402,6 +402,27 @@ class Test_Tabulation(unittest.TestCase):
         clipped = tabr.clip(4.5, 5.5)
         self.assertEqual(clipped.domain(), (4.5, 5.5))
         self.assertEqual(clipped.integral(), 5.)
+
+        clipped = tabr.clip(0, 12)
+        self.assertEqual(clipped.domain(), (0, 11))
+        self.assertEqual(clipped(0), 0)
+        self.assertEqual(clipped(0.5), 0.5)
+        self.assertEqual(clipped(11), 0)
+
+        clipped = tabr.clip(-10, 20)
+        self.assertEqual(clipped.domain(), (0, 11))
+        self.assertEqual(clipped(0), 0)
+        self.assertEqual(clipped(0.5), 0.5)
+        self.assertEqual(clipped(11), 0)
+
+        clipped = tabr.clip(0.5, 10)
+        self.assertEqual(clipped.domain(), (0.5, 10))
+        self.assertEqual(clipped(0.4), 0)
+        self.assertEqual(clipped(0.5), 0.5)
+        self.assertEqual(clipped(0.6), 0.6)
+        self.assertEqual(clipped(10), 10)
+        self.assertEqual(clipped(10.1), 0)
+        self.assertEqual(clipped(11), 0)
 
         with self.assertRaises(ValueError) as context:
             tabr.clip(15, 16)

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -12,6 +12,12 @@ class Test_Tabulation(unittest.TestCase):
 
     def runTest(self):
 
+        tab = Tabulation([], [])
+        self.assertEqual(tab.domain(), (0., 0.))
+        self.assertEqual(tab(0), 0)
+        self.assertEqual(tab(-1), 0)
+        self.assertEqual(tab(1), 0)
+
         # Ramp-style edges
         # xr = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         # yr = [0, 0, 0, 1, 2, 6, 1, 0, 0]
@@ -46,12 +52,16 @@ class Test_Tabulation(unittest.TestCase):
         self.assertTrue(np.all(np.array([3.5, 4.5, 5.5]) == tabs([3.5, 4.5, 5.5])))
         self.assertTrue(tabs.integral(), 50.)
 
-        # RESAMPLE #
+        # RESAMPLE
+
+        resampled = tabs.resample(None)
+
+        self.assertTrue(np.all(resampled.x == xs))
+        self.assertTrue(np.all(resampled.y == ys))
 
         with self.assertRaises(ValueError) as context:
             tabs.resample([-4, -5, -3])
-        self.assertEqual(
-            str(context.exception), "x-coordinates are not monotonic")
+        self.assertEqual(str(context.exception), "x-coordinates are not monotonic")
 
         # All off left side
         resampled = tabs.resample([-5, -4])
@@ -71,6 +81,10 @@ class Test_Tabulation(unittest.TestCase):
         self.assertEqual(resampled.x.shape, (19,))
         self.assertEqual(resampled.domain(), (1, 10))
         resampled = tabr.resample(np.arange(1, 10.1, 0.5))
+        self.assertTrue(np.all(resampled.y == resampled.x))
+        self.assertEqual(resampled.x.shape, (19,))
+        self.assertEqual(resampled.domain(), (1, 10))
+        resampled = tabr.resample(np.arange(10, 0.5, -0.5))
         self.assertTrue(np.all(resampled.y == resampled.x))
         self.assertEqual(resampled.x.shape, (19,))
         self.assertEqual(resampled.domain(), (1, 10))
@@ -114,6 +128,11 @@ class Test_Tabulation(unittest.TestCase):
         self.assertEqual(resampled.domain(), (10, 15))
 
         # SUBSAMPLE
+
+        subsampled = tabs.subsample(None)
+
+        self.assertTrue(np.all(subsampled.x == xs))
+        self.assertTrue(np.all(subsampled.y == ys))
 
         subsampled = tabs.subsample(np.array([5.2, 5.5, 6., 7.]))
         self.assertTrue(np.all(subsampled.x ==
@@ -164,273 +183,252 @@ class Test_Tabulation(unittest.TestCase):
                                                   8.,  9])))
         self.assertTrue(np.all(res.y == np.array([1, 2, 3, 3.499999999999999, 4.5,
                                                   6, 8, 5, 3.999999999999999, 3, 2])))
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)+tab2(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(np.all(
+            np.abs((tab1(off_xlist) + tab2(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab2 + tab1
-        self.assertTrue(np.all(np.abs((tab2(off_xlist)+tab1(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab2(off_xlist) + tab1(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab3 + tab4
-        self.assertTrue(np.all(res.x == np.array([1., 2., 3., 4., 4.3, 5.3, 6.1,
-                                                  6.3, 7.1, 7.3, 8.1, 8.4])))
-        self.assertTrue(np.all(res.y-np.array([0., 1., 2., 3., 4., 4.5, 5.9,
-                                               6.2, 3., 2.2, 3., 0.]))<1e-10)
-        self.assertTrue(np.all(np.abs((tab3(off_xlist)+tab4(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(res.x == np.array([1., 2., 3., 4., 4.3, 5.3, 6.1,
+                                      6.3, 7.1, 7.3, 8.1, 8.4])))
+        self.assertTrue(
+            np.all(res.y-np.array([0., 1., 2., 3., 4., 4.5, 5.9,
+                                   6.2, 3., 2.2, 3., 0.])) < 1e-10)
+        self.assertTrue(
+            np.all(np.abs((tab3(off_xlist) + tab4(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab4 + tab3
-        self.assertTrue(np.all(np.abs((tab4(off_xlist)+tab3(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab4(off_xlist) + tab3(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab1 + tab3
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)+tab3(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab1(off_xlist) + tab3(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab3 + tab1
-        self.assertTrue(np.all(np.abs((tab3(off_xlist)+tab1(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab3(off_xlist) + tab1(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab2 + tab4
-        self.assertTrue(np.all(np.abs((tab2(off_xlist)+tab4(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab2(off_xlist) + tab4(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab4 + tab2
-        self.assertTrue(np.all(np.abs((tab4(off_xlist)+tab2(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab4(off_xlist) + tab2(off_xlist) - res(off_xlist))) < 1e-10))
 
         tab5 = Tabulation(x1, y1)
         tab5 += tab2
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)+tab2(off_xlist)-tab5(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab1(off_xlist) + tab2(off_xlist)-tab5(off_xlist))) < 1e-10))
 
         with self.assertRaises(ValueError) as context:
             _ = tab1 + np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot add Tabulation by given value"
-            )
+        self.assertEqual(str(context.exception), "Cannot add Tabulation by given value")
 
         with self.assertRaises(ValueError) as context:
             _ = tab1 + 5
-        self.assertEqual(
-            str(context.exception),
-            "Cannot add Tabulation by given value"
-            )
+        self.assertEqual(str(context.exception), "Cannot add Tabulation by given value")
 
         with self.assertRaises(ValueError) as context:
             tab1 += np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot add Tabulation in-place by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot add Tabulation in-place by given value")
 
         with self.assertRaises(ValueError) as context:
             tab1 += 5
-        self.assertEqual(
-            str(context.exception),
-            "Cannot add Tabulation in-place by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot add Tabulation in-place by given value")
 
         # SUBTRACTION
 
         res = tab1 - tab2
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)-tab2(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab1(off_xlist)-tab2(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab2 - tab1
-        self.assertTrue(np.all(np.abs((tab2(off_xlist)-tab1(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab2(off_xlist)-tab1(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab3 - tab4
-        self.assertTrue(np.all(np.abs((tab3(off_xlist)-tab4(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab3(off_xlist)-tab4(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab4 - tab3
-        self.assertTrue(np.all(np.abs((tab4(off_xlist)-tab3(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab4(off_xlist)-tab3(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab1 - tab3
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)-tab3(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab1(off_xlist)-tab3(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab3 - tab1
-        self.assertTrue(np.all(np.abs((tab3(off_xlist)-tab1(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab3(off_xlist)-tab1(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab2 - tab4
-        self.assertTrue(np.all(np.abs((tab2(off_xlist)-tab4(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab2(off_xlist)-tab4(off_xlist) - res(off_xlist))) < 1e-10))
 
         res = tab4 - tab2
-        self.assertTrue(np.all(np.abs((tab4(off_xlist)-tab2(off_xlist)-res(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab4(off_xlist)-tab2(off_xlist) - res(off_xlist))) < 1e-10))
 
         tab5 = Tabulation(x1, y1)
         tab5 -= tab2
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)-tab2(off_xlist)-tab5(off_xlist)))<1e-10))
+        self.assertTrue(
+            np.all(np.abs((tab1(off_xlist)-tab2(off_xlist)-tab5(off_xlist))) < 1e-10))
 
         with self.assertRaises(ValueError) as context:
             _ = tab1 - np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot subtract Tabulation by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot subtract Tabulation by given value")
 
         with self.assertRaises(ValueError) as context:
             _ = tab1 - 5
-        self.assertEqual(
-            str(context.exception),
-            "Cannot subtract Tabulation by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot subtract Tabulation by given value")
 
         with self.assertRaises(ValueError) as context:
             tab1 -= np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot subtract Tabulation in-place by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot subtract Tabulation in-place by given value")
 
         with self.assertRaises(ValueError) as context:
             tab1 -= 5
-        self.assertEqual(
-            str(context.exception),
-            "Cannot subtract Tabulation in-place by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot subtract Tabulation in-place by given value")
 
         # MULTIPLICATION
 
         res = tab1 * tab2
-        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab2(tab1.x)-res(tab1.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab1(tab2.x)*tab2(tab2.x)-res(tab2.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab2(tab1.x) - res(tab1.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab2.x)*tab2(tab2.x) - res(tab2.x))) < 1e-10))
 
         res = tab2 * tab1
-        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab2(tab1.x)-res(tab1.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab1(tab2.x)*tab2(tab2.x)-res(tab2.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab2(tab1.x) - res(tab1.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab2.x)*tab2(tab2.x) - res(tab2.x))) < 1e-10))
 
         res = tab3 * tab4
-        self.assertTrue(np.all(np.abs((tab3(tab3.x)*tab4(tab3.x)-res(tab3.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab3(tab4.x)*tab4(tab4.x)-res(tab4.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab3(tab3.x)*tab4(tab3.x) - res(tab3.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab3(tab4.x)*tab4(tab4.x) - res(tab4.x))) < 1e-10))
 
         res = tab4 * tab3
-        self.assertTrue(np.all(np.abs((tab3(tab3.x)*tab4(tab3.x)-res(tab3.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab3(tab4.x)*tab4(tab4.x)-res(tab4.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab3(tab3.x)*tab4(tab3.x) - res(tab3.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab3(tab4.x)*tab4(tab4.x) - res(tab4.x))) < 1e-10))
 
         res = tab1 * tab3
-        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab3(tab1.x)-res(tab1.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab1(tab3.x)*tab3(tab3.x)-res(tab3.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab3(tab1.x) - res(tab1.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab3.x)*tab3(tab3.x) - res(tab3.x))) < 1e-10))
 
         res = tab3 * tab1
-        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab3(tab1.x)-res(tab1.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab1(tab3.x)*tab3(tab3.x)-res(tab3.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab3(tab1.x) - res(tab1.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab3.x)*tab3(tab3.x) - res(tab3.x))) < 1e-10))
 
         res = tab2 * tab4
-        self.assertTrue(np.all(np.abs((tab2(tab2.x)*tab4(tab2.x)-res(tab2.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab2(tab4.x)*tab4(tab4.x)-res(tab4.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab2(tab2.x)*tab4(tab2.x) - res(tab2.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab2(tab4.x)*tab4(tab4.x) - res(tab4.x))) < 1e-10))
 
         res = tab4 * tab2
-        self.assertTrue(np.all(np.abs((tab2(tab2.x)*tab4(tab2.x)-res(tab2.x)))<1e-10))
-        self.assertTrue(np.all(np.abs((tab2(tab4.x)*tab4(tab4.x)-res(tab4.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab2(tab2.x)*tab4(tab2.x) - res(tab2.x))) < 1e-10))
+        self.assertTrue(np.all(np.abs((tab2(tab4.x)*tab4(tab4.x) - res(tab4.x))) < 1e-10))
 
         res = tab1 * 10
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)*10-res(off_xlist)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(off_xlist)*10 - res(off_xlist))) < 1e-10))
 
         tab5 = Tabulation(x1, y1)
         tab5 *= tab2
-        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab2(tab1.x)-tab5(tab1.x)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(tab1.x)*tab2(tab1.x)-tab5(tab1.x))) < 1e-10))
 
         tab5 = Tabulation(x1, y1)
         tab5 *= 10
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)*10-tab5(off_xlist)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(off_xlist)*10-tab5(off_xlist))) < 1e-10))
 
         with self.assertRaises(ValueError) as context:
             _ = tab1 * np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot multiply Tabulation by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot multiply Tabulation by given value")
 
         with self.assertRaises(ValueError) as context:
             tab1 *= np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot multiply Tabulation in-place by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot multiply Tabulation in-place by given value")
 
         # DIVISION
 
         res = tab1 / 10
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)/10-res(off_xlist)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(off_xlist)/10 - res(off_xlist))) < 1e-10))
 
         tab5 = Tabulation(x1, y1)
         tab5 /= 10
-        self.assertTrue(np.all(np.abs((tab1(off_xlist)/10-tab5(off_xlist)))<1e-10))
+        self.assertTrue(np.all(np.abs((tab1(off_xlist)/10 - tab5(off_xlist))) < 1e-10))
 
         with self.assertRaises(ValueError) as context:
             _ = tab1 / np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot divide Tabulation by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot divide Tabulation by given value")
 
         with self.assertRaises(ValueError) as context:
             tab1 /= np.array([])
-        self.assertEqual(
-            str(context.exception),
-            "Cannot divide Tabulation in-place by given value"
-            )
+        self.assertEqual(str(context.exception),
+                         "Cannot divide Tabulation in-place by given value")
 
         # LOCATE
 
-        for x in xlist:
-            self.assertEqual(tab.locate(x)[0], x)
-            self.assertEqual(len(tab.locate(x)), 1)
+        for x in xs:
+            self.assertEqual(tabs.locate(x)[0], x)
+            self.assertEqual(len(tabs.locate(x)), 1)
+
+        for x in xs[:-1]:
+            self.assertEqual(tabs.locate(x+x/10)[0], x+x/10)
+            self.assertEqual(len(tabs.locate(x+x/10)), 1)
+
+        for x in xr[2:-3]:
+            self.assertEqual(tabr.locate(x+x/10)[0], x+x/10)
+            self.assertEqual(len(tabr.locate(x+x/10)), 2)
+
+        self.assertEqual(tabr.locate(0.), [0, 11])
+        self.assertEqual(tabr.locate(4.5), [4.5, 10.55])
 
         # CLIP
 
-        clipped = resampled.clip(2, 5)
+        clipped = tabr.clip(2, 5)
         self.assertEqual(clipped.domain(), (2., 5.))
         self.assertEqual(clipped.integral(), 10.5)
 
-        clipped = resampled.clip(4.5, 5.5)
+        clipped = tabr.clip(4.5, 5.5)
         self.assertEqual(clipped.domain(), (4.5, 5.5))
         self.assertEqual(clipped.integral(), 5.)
 
         with self.assertRaises(ValueError) as context:
-            resampled.clip(-5, 10)
-        self.assertEqual(str(context.exception),
-                         "Clipping operation changed leading edge to ramp-style")
-        with self.assertRaises(ValueError) as context:
-            resampled.clip(2, 12)
-        self.assertEqual(str(context.exception),
-                         "Clipping operation changed trailing edge to ramp-style")
+            tabr.clip(15, 16)
+        self.assertEqual(str(context.exception), "Domains do not overlap")
 
-        ratio = tab / clipped
-        self.assertEqual(ratio.domain(), (4.5, 5.5))
-        self.assertEqual(ratio(4.49999), 0.)
-        self.assertEqual(ratio(4.5), 1.)
-        self.assertEqual(ratio(5.1), 1.)
-        self.assertEqual(ratio(5.5), 1.)
-        self.assertEqual(ratio(5.500001), 0.)
-
-        product = ratio * clipped
-        self.assertEqual(product.domain(), (4.5, 5.5))
-        self.assertEqual(product(4.49999), 0.)
-        self.assertEqual(product(4.5), 4.5)
-        self.assertEqual(product(5.1), 5.1)
-        self.assertEqual(product(5.5), 5.5)
-        self.assertEqual(product(5.500001), 0.)
-
-        # Test ramp/step checking
-        ramp1 = Tabulation(np.arange(5), np.arange(5))  # First y == 0
-        ramp2 = Tabulation(np.arange(5), np.arange(-4, 1))  # Last y == 0
-        _ = resampled * resampled
-
-        # CENTER
+        # X_MEAN
 
         boxcar = Tabulation((0., 10.), (1., 1.))
-        self.assertEqual(boxcar.mean(), 1.)
+        self.assertEqual(boxcar.x_mean(), 5.)
+
+        self.assertTrue(np.abs(boxcar.x_mean(0.33) - 5.) < 1e-10)
 
         # BANDWIDTH_RMS
+        self.assertTrue(np.abs(boxcar.bandwidth_rms() - 5.) < 1e-7)
+        self.assertTrue(np.abs(boxcar.bandwidth_rms(0.001) - 5. / np.sqrt(3.)) < 1e-7)
 
-        value = 5. / np.sqrt(3.)
-        eps = 1.e-7
-        self.assertTrue(np.abs(boxcar.bandwidth_rms() - value) < eps)
+        boxcar = Tabulation((10000, 10010),(1, 1))
+        self.assertEqual(boxcar.x_mean(), 10005.)
 
         # PIVOT_MEAN
 
-        # For narrow functions, the pivot_mean and the mean are similar
-        eps = 1.e-3
-        self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - 1.) < eps)
+        # For narrow functions, the pivot_mean and the x_mean are similar
+        self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - 10005.) < 1e-3)
 
         # For broad functions, values differ
         boxcar = Tabulation((1, 100), (1, 1))
-        value = 99. / np.log(100.)
-        eps = 1.e-3
-        self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - value) < eps)
+        self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - 99. / np.log(100.)) < 1e-3)
 
         # FWHM
 
@@ -455,7 +453,7 @@ class Test_Tabulation(unittest.TestCase):
         # SQUARE_WIDTH
 
         self.assertEqual(triangle.square_width(), 10.)
-        self.assertEqual(boxcar.square_width(), 10.)
+        self.assertEqual(boxcar.square_width(), 99.)
 
         # INITIALIZATION ERRORS
 
@@ -479,16 +477,14 @@ class Test_Tabulation(unittest.TestCase):
         y = np.array([4, 5, 6])
         with self.assertRaises(ValueError) as context:
             Tabulation(x, y)
-        self.assertEqual(
-            str(context.exception), "x-coordinates are not monotonic")
+        self.assertEqual(str(context.exception), "x-coordinates are not monotonic")
 
         # Test initialization with a non-monotonic x array (with floats)
         x = np.array([1., 3., 2.])  # Non-monotonic
         y = np.array([4., 5., 6.])
         with self.assertRaises(ValueError) as context:
             Tabulation(x, y)
-        self.assertEqual(
-            str(context.exception), "x-coordinates are not monotonic")
+        self.assertEqual(str(context.exception), "x-coordinates are not monotonic")
 
         # Test update with new_y having a different size than x
         x = np.array([1, 2, 3])
@@ -497,38 +493,19 @@ class Test_Tabulation(unittest.TestCase):
         new_y = np.array([7, 8])  # Mismatched size
         with self.assertRaises(ValueError) as context:
             tab._update_y(new_y)
-        self.assertEqual(
-            str(context.exception),
-            "x and y arrays do not have the same size"
-            )
+        self.assertEqual(str(context.exception),
+                         "x and y arrays do not have the same size")
 
         # Test xmerge with non-overlapping domains
         x1 = np.array([1, 2, 3])
         x2 = np.array([4, 5, 6])
         with self.assertRaises(ValueError) as context:
-            result = Tabulation._xmerge(x1, x2)
-        self.assertEqual(str(context.exception), "domains do not overlap")
+            Tabulation._xmerge(x1, x2)
+        self.assertEqual(str(context.exception), "Domains do not overlap")
 
         # Test xmerge with non-overlapping domains (with floats)
         x1 = np.array([1., 2., 3.])
         x2 = np.array([4., 5., 6.])
         with self.assertRaises(ValueError) as context:
-            result = Tabulation._xmerge(x1, x2)
-        self.assertEqual(str(context.exception), "domains do not overlap")
-
-        # resample where x=None
-        x = np.array([1, 2, 3])
-        y = np.array([4, 5, 6])
-
-        tab = Tabulation(x, y)
-
-        resampled = tab.resample(None)
-
-        self.assertTrue(np.all(resampled.x == x))
-        self.assertTrue(np.all(resampled.y == y))
-
-        # bandwidth_rms with dx=None
-        # boxcar = Tabulation((0., 10.), (1., 1.))
-        # value = 5
-
-        # self.assertTrue(np.abs(boxcar.bandwidth_rms() - value) == 0.)
+            Tabulation._xmerge(x1, x2)
+        self.assertEqual(str(context.exception), "Domains do not overlap")

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -7,6 +7,7 @@ from tabulation import Tabulation
 import numpy as np
 import unittest
 
+
 class Test_Tabulation(unittest.TestCase):
 
     def runTest(self):
@@ -14,29 +15,29 @@ class Test_Tabulation(unittest.TestCase):
         x = np.arange(11)
         y = np.arange(11)
 
-        tab = Tabulation(x,y)
+        tab = Tabulation(x, y)
 
         self.assertEqual(4., tab(4))
         self.assertEqual(4.5, tab(4.5))
         self.assertEqual(0., tab(10.000000001))
 
-        self.assertEqual(tab.domain(), (0.,10.))
+        self.assertEqual(tab.domain(), (0., 10.))
 
-        reversed = Tabulation(x[::-1],y)
+        reversed = Tabulation(x[::-1], y)
         self.assertEqual(4., reversed(6))
         self.assertEqual(4.5, reversed(5.5))
         self.assertEqual(0., reversed(10.000000001))
 
-        self.assertTrue(np.all(np.array((3.5,4.5,5.5)) == tab((3.5,4.5,5.5))))
+        self.assertTrue(np.all(np.array((3.5, 4.5, 5.5)) == tab((3.5, 4.5, 5.5))))
         self.assertTrue(tab.integral(), 50.)
 
-        resampled = tab.resample(np.arange(0,10.5,0.5))
+        resampled = tab.resample(np.arange(0, 10.5, 0.5))
         self.assertTrue(np.all(resampled.y == resampled.x))
 
-        resampled = tab.resample(np.array((0.,10.)))
+        resampled = tab.resample(np.array((0., 10.)))
         self.assertTrue(np.all(resampled.y == resampled.x))
 
-        xlist = np.arange(0.,10.25,0.25)
+        xlist = np.arange(0., 10.25, 0.25)
         self.assertTrue(np.all(xlist == resampled(xlist)))
         self.assertTrue(np.all(xlist == tab(xlist)))
 
@@ -60,16 +61,16 @@ class Test_Tabulation(unittest.TestCase):
             self.assertEqual(tab.locate(x)[0], x)
             self.assertEqual(len(tab.locate(x)), 1)
 
-        clipped = resampled.clip(-5,5)
-        self.assertEqual(clipped.domain(), (-5.,5.))
+        clipped = resampled.clip(-5, 5)
+        self.assertEqual(clipped.domain(), (-5., 5.))
         self.assertEqual(clipped.integral(), 12.5)
 
-        clipped = resampled.clip(4.5,5.5)
-        self.assertEqual(clipped.domain(), (4.5,5.5))
+        clipped = resampled.clip(4.5, 5.5)
+        self.assertEqual(clipped.domain(), (4.5, 5.5))
         self.assertEqual(clipped.integral(), 5.)
 
         ratio = tab / clipped
-        self.assertEqual(ratio.domain(), (4.5,5.5))
+        self.assertEqual(ratio.domain(), (4.5, 5.5))
         self.assertEqual(ratio(4.49999), 0.)
         self.assertEqual(ratio(4.5), 1.)
         self.assertEqual(ratio(5.1), 1.)
@@ -77,7 +78,7 @@ class Test_Tabulation(unittest.TestCase):
         self.assertEqual(ratio(5.500001), 0.)
 
         product = ratio * clipped
-        self.assertEqual(product.domain(), (4.5,5.5))
+        self.assertEqual(product.domain(), (4.5, 5.5))
         self.assertEqual(product(4.49999), 0.)
         self.assertEqual(product(4.5), 4.5)
         self.assertEqual(product(5.1), 5.1)
@@ -85,41 +86,36 @@ class Test_Tabulation(unittest.TestCase):
         self.assertEqual(product(5.500001), 0.)
 
         # mean()
-        boxcar = Tabulation((0., 10.),(1., 1.))
-        self.assertEqual(boxcar.mean(), 5.)
-
-        eps = 1.e-14
-        self.assertTrue(np.abs(boxcar.mean(0.33) - 5.) < eps)
+        boxcar = Tabulation((0., 10.), (1., 1.))
+        self.assertEqual(boxcar.mean(), 1.)
 
         # bandwidth_rms()
-        value = 5. / np.sqrt(3.)
-        eps = 1.e-7
-        self.assertTrue(np.abs(boxcar.bandwidth_rms(0.001) - value) < eps)
-
-        boxcar = Tabulation((10000,10010),(1,1))
-        self.assertEqual(boxcar.mean(), 10005.)
+        # value = 5. / np.sqrt(3.)
+        # eps = 1.e-7
+        # self.assertTrue(np.abs(boxcar.bandwidth_rms() - value) < eps)
 
         # pivot_mean()
         # For narrow functions, the pivot_mean and the mean are similar
-        eps = 1.e-3
-        self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - 10005.) < eps)
+        # eps = 1.e-3
+        # print(boxcar.pivot_mean(1.e-6))
+        # self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - 1.) < eps)
 
-        # For broad functions, values differ
-        boxcar = Tabulation((1,100),(1,1))
-        value = 99. / np.log(100.)
-        eps = 1.e-3
-        self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - value) < eps)
+        # # For broad functions, values differ
+        # boxcar = Tabulation((1, 100), (1, 1))
+        # value = 99. / np.log(100.)
+        # eps = 1.e-3
+        # self.assertTrue(np.abs(boxcar.pivot_mean(1.e-6) - value) < eps)
 
         # fwhm()
-        triangle = Tabulation((0,10,20),(0,1,0))
+        triangle = Tabulation((0, 10, 20), (0, 1, 0))
         self.assertEqual(triangle.fwhm(), 10.)
 
-        triangle = Tabulation((0,10,20),(0,1,0))
+        triangle = Tabulation((0, 10, 20), (0, 1, 0))
         self.assertEqual(triangle.fwhm(0.25), 15.)
 
         # square_width()
         self.assertEqual(triangle.square_width(), 10.)
-        self.assertEqual(boxcar.square_width(), 99.)
+        self.assertEqual(boxcar.square_width(), 10.)
 
         # Not 1 dimensional x
         x = np.array([[1, 2], [3, 4]])  # 2-dimensional array
@@ -133,7 +129,8 @@ class Test_Tabulation(unittest.TestCase):
         y = np.array([4, 5])  # Mismatched size
         with self.assertRaises(ValueError) as context:
             Tabulation(x, y)
-        self.assertEqual(str(context.exception), "x and y arrays do not have the same size")
+        self.assertEqual(str(context.exception),
+                         "x and y arrays do not have the same size")
 
         # Test initialization with a non-monotonic x array
         x = np.array([1, 3, 2])  # Non-monotonic
@@ -181,7 +178,7 @@ class Test_Tabulation(unittest.TestCase):
         x = np.array([1, 2, 3])
         y = np.array([4, 5, 6])
 
-        tab = Tabulation(x,y)
+        tab = Tabulation(x, y)
 
         resampled = tab.resample(None)
 
@@ -189,10 +186,10 @@ class Test_Tabulation(unittest.TestCase):
         self.assertTrue(np.all(resampled.y == y))
 
         # bandwidth_rms with dx=None
-        boxcar = Tabulation((0., 10.),(1., 1.))
-        value = 5
+        # boxcar = Tabulation((0., 10.), (1., 1.))
+        # value = 5
 
-        self.assertTrue(np.abs(boxcar.bandwidth_rms() - value) == 0.)
+        # self.assertTrue(np.abs(boxcar.bandwidth_rms() - value) == 0.)
 
         # Test multiplication of Two Tabulations
         x1 = np.array([1, 2, 3])
@@ -205,7 +202,7 @@ class Test_Tabulation(unittest.TestCase):
 
         result = tab1 * tab2
 
-        expected_x = [1, 2, 3] # Merged x values
+        expected_x = [1, 2, 3]  # Merged x values
 
         self.assertTrue(np.array_equal(result.x, expected_x))
         self.assertTrue(np.array_equal(result(x), tab1(x) * tab2(x)))
@@ -224,7 +221,6 @@ class Test_Tabulation(unittest.TestCase):
         assert np.array_equal(result(x), tab(x) * scalar)
         assert np.array_equal(result.y, tab.y * scalar)
         assert np.array_equal(result.y, y * scalar)
-
 
         # Test multiplication of Two Tabulations with a scalar (with floats)
         x = np.array([1., 2., 3.])
@@ -373,7 +369,7 @@ class Test_Tabulation(unittest.TestCase):
         self.assertTrue(np.array_equal(tab(x), np.array([4, 5, 6]) + scalar))
         self.assertTrue(np.array_equal(y + scalar, np.array([4, 5, 6]) + scalar))
 
-       # Test addition of two Tabulations with a scalar (with floats)
+        # Test addition of two Tabulations with a scalar (with floats)
         x = np.array([1., 2., 3.])
         y = np.array([4., 5., 6.])
         tab = Tabulation(x, y)
@@ -430,7 +426,7 @@ class Test_Tabulation(unittest.TestCase):
             "Cannot add Tabulation by given value"
             )
 
-        # Test subtraction of two Tabulations 
+        # Test subtraction of two Tabulations
         x1 = np.array([1, 2, 3])
         y1 = np.array([4, 5, 6])
         tab1 = Tabulation(x1, y1)
@@ -441,7 +437,7 @@ class Test_Tabulation(unittest.TestCase):
 
         result = tab1 - tab2
 
-        expected_x = [1, 2, 3] # Merged x values
+        expected_x = [1, 2, 3]  # Merged x values
 
         self.assertTrue(np.array_equal(result.x, expected_x))
         self.assertTrue(np.array_equal(result.y, tab1.y - tab2.y))
@@ -516,4 +512,3 @@ class Test_Tabulation(unittest.TestCase):
             str(context.exception),
             "Cannot subtract Tabulation in-place by given value"
             )
-        

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -470,6 +470,14 @@ class Test_Tabulation(unittest.TestCase):
             more_triangle.fwhm(0.5)
         self.assertEqual(str(context.exception),
                          "Tabulation does not cross fractional height twice")
+        with self.assertRaises(ValueError) as context:
+            more_triangle.fwhm(-0.0001)
+        self.assertEqual(str(context.exception),
+                         "fraction is outside the range 0-1")
+        with self.assertRaises(ValueError) as context:
+            more_triangle.fwhm(1.0001)
+        self.assertEqual(str(context.exception),
+                         "fraction is outside the range 0-1")
 
         # SQUARE_WIDTH
 

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -12,6 +12,14 @@ class Test_Tabulation(unittest.TestCase):
 
     def runTest(self):
 
+        x = [0, 1, 2, 3, 4, 5, 6, 7]
+        y = [0, 0, 0, 1, 2, 3, 0, 0]
+        tab = Tabulation(x, y)
+        self.assertEqual(tab.domain(), (0., 7.))
+        tab1 = tab.trim()
+        self.assertEqual(tab.domain(), (0., 7.))
+        self.assertEqual(tab1.domain(), (2., 6.))
+
         x = np.arange(11)
         y = np.arange(11)
 
@@ -22,6 +30,9 @@ class Test_Tabulation(unittest.TestCase):
         self.assertEqual(0., tab(10.000000001))
 
         self.assertEqual(tab.domain(), (0., 10.))
+        tab1 = tab.trim()
+        self.assertEqual(tab.domain(), (0., 10.))
+        self.assertEqual(tab1.domain(), (0., 10.))
 
         reversed = Tabulation(x[::-1], y)
         self.assertEqual(4., reversed(6))
@@ -35,6 +46,12 @@ class Test_Tabulation(unittest.TestCase):
         self.assertTrue(np.all(resampled.y == resampled.x))
 
         resampled = tab.resample(np.array((0., 10.)))
+        self.assertTrue(np.all(resampled.y == resampled.x))
+
+        subsampled = tab.subsample(np.array([5.2, 5.5, 6., 7.]))
+        self.assertTrue(np.all(subsampled.x ==
+                               np.array([0., 1., 2., 3., 4., 5., 5.2, 5.5,
+                                         6., 7., 8., 9., 10.])))
         self.assertTrue(np.all(resampled.y == resampled.x))
 
         xlist = np.arange(0., 10.25, 0.25)
@@ -112,6 +129,18 @@ class Test_Tabulation(unittest.TestCase):
 
         triangle = Tabulation((0, 10, 20), (0, 1, 0))
         self.assertEqual(triangle.fwhm(0.25), 15.)
+
+        less_triangle = Tabulation((0, 10), (0, 1))
+        with self.assertRaises(ValueError) as context:
+            less_triangle.fwhm(0.5)
+        self.assertEqual(str(context.exception),
+                         "Tabulation does not cross fractional height twice")
+
+        more_triangle = Tabulation((0, 10, 20, 30), (0, 1, 0, 1))
+        with self.assertRaises(ValueError) as context:
+            more_triangle.fwhm(0.5)
+        self.assertEqual(str(context.exception),
+                         "Tabulation does not cross fractional height twice")
 
         # square_width()
         self.assertEqual(triangle.square_width(), 10.)


### PR DESCRIPTION
# Fixed Issues

- Fixes #1 
- Fixes #3 
- Fixes #8 

# Summary of Changes

Prepare `rms-tabulation` for public deployment.

- Code and testing:
  - Implement new rigorous semantics for leading and trailing zeros; see documentation
  - Clean up code, including PEP8-compliance
  - Improve and maintain test coverage at 100%
  - Update the automated tests to run `flake8`
- Documentation:
  - Write a new `README.md` including installation instructions and examples
  - Convert docstrings to Google style
  - Add Sphinx documentation and `readthedocs.io` integration
- Misc:
  - Add the Pull Request template `pull_request_template.md`

This PR represents a fairly major change to the semantics of Tabulation, while still attempting to preserve past behavior as much as possible. The fundamental issue is that Tabulation was only used by our own code base in places where it represented the spectral flux from the Sun or the bandpass of a filter. Thus the Tabulation was zero outside of the "valid" range, since there was no flux or no transmission, and never zero within the "valid" range. It also represented a fairly smooth function. So when you added or multiplied two tabulations, it didn't really matter what happened at the exact edges of the valid range.

However, this can also be a general module, and for that the edge cases need to be well-defined. This turns out to be very tricky, because Tabulation has two ways of handling edges - they can be ramps from zero to the given y value, or they can be step functions directly to the given y value. It gets even more complicated when you try to do things like add or multiply two Tabulations, one having a ramp and the other a step.

I've attempted to document the behavior in the README.md file with examples. Please let me know if they are unclear.

# Known Problems

None.