### PR TITLE
Fix for handling of duplicated x-values

### DIFF
--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -19,8 +19,11 @@ from scipy.interpolate import interp1d
 
 try:
     from math import nextafter  # Only in Python 3.9 and later
-except ImportError:  # pragma: no cover
-    from numpy import nextafter
+except ImportError:             # pragma: no cover
+    def nextafter(x, y, /, *, steps=1):
+        for i in range(steps):
+            x = np.nextafter(x, y)
+        return x
 
 try:
     from ._version import __version__

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -18,11 +18,18 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 try:
-    from math import nextafter  # Only in Python 3.9 and later
-except ImportError:             # pragma: no cover
+    from math import nextafter as _nextafter    # Only in Python 3.9 and later
+except ImportError:                             # pragma: no cover
+    from numpy import nextafter as _nextafter
+
+# We use the `steps` option only implemented in Python 3.12. Sheesh. Here's a workaround.
+nextafter = _nextafter
+try:
+    x = nextafter(1, math.inf, steps=2)
+except TypeError:
     def nextafter(x, y, /, *, steps=1):
         for i in range(steps):
-            x = np.nextafter(x, y)
+            x = _nextafter(x, y)
         return x
 
 try:

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -26,7 +26,7 @@ except ImportError:                             # pragma: no cover
 nextafter = _nextafter
 try:
     x = nextafter(1, math.inf, steps=2)
-except TypeError:
+except TypeError:                               # pragma: no cover
     def nextafter(x, y, /, *, steps=1):
         for i in range(steps):
             x = _nextafter(x, y)

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -168,9 +168,9 @@ class Tabulation(object):
 
             for i in dups:
                 if abs(y[i]) < abs(y[i+1]):
-                    x[i] = math.nextafter(x[i], -math.inf)
+                    x[i] = nextafter(x[i], -math.inf)
                 else:
-                    x[i+1] = math.nextafter(x[i], math.inf)
+                    x[i+1] = nextafter(x[i], math.inf)
 
         self.x = x
         self.y = y
@@ -659,13 +659,13 @@ class Tabulation(object):
         # Strip bounding x-values that are within 3 * epsilon of the adjacent x
         xmin = self.x[0]
         if self.y[0] == 0. and self.y[1] != 0.:
-            limit = math.nextafter(self.x[1], -math.inf, steps=3)
+            limit = nextafter(self.x[1], -math.inf, steps=3)
             if self.x[0] > limit:
                 xmin = self.x[1]
 
         xmax = self.x[-1]
         if self.y[-1] == 0. and self.y[-2] != 0.:
-            limit = math.nextafter(self.x[-2], math.inf, steps=3)
+            limit = nextafter(self.x[-2], math.inf, steps=3)
             if self.x[-1] < limit:
                 xmax = self.x[-2]
 

--- a/tabulation/__init__.py
+++ b/tabulation/__init__.py
@@ -156,7 +156,7 @@ class Tabulation(object):
             x = x[first:last+1]
             y = y[first:last+1]
 
-            # Make sure the sequence is monotonic but tolerate duplicates fo rnow
+            # Make sure the sequence is monotonic but tolerate duplicates for now
             mask = x[:-1] <= x[1:]
             if not np.all(mask):
                 raise ValueError('x-coordinates are not strictly monotonic')

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -2,16 +2,11 @@
 # UNIT TESTS
 ########################################
 
-from tabulation import Tabulation
+from tabulation import Tabulation, nextafter
 
 import math
 import numpy as np
 import unittest
-
-try:
-    from math import nextafter  # Only in Python 3.9 and later
-except ImportError:  # pragma: no cover
-    from numpy import nextafter
 
 
 class Test_Tabulation(unittest.TestCase):
@@ -669,3 +664,7 @@ class Test_Tabulation(unittest.TestCase):
         answer = np.array([3.98, 3.99, 4., 1.01, 1.02])
         diff = tab(x) - answer
         self.assertLess(np.abs(diff).max(), 1.e-15)
+
+        # nextafter using steps
+        self.assertEqual(nextafter(1., 2., steps=1), 1.0000000000000002)
+        self.assertEqual(nextafter(1., 2., steps=2), 1.0000000000000004)

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -8,6 +8,11 @@ import math
 import numpy as np
 import unittest
 
+try:
+    from math import nextafter  # Only in Python 3.9 and later
+except ImportError:  # pragma: no cover
+    from numpy import nextafter
+
 
 class Test_Tabulation(unittest.TestCase):
 
@@ -625,8 +630,8 @@ class Test_Tabulation(unittest.TestCase):
         self.assertEqual(tab.domain(), (3, 3))
         self.assertEqual(tab(3), 7)
         self.assertEqual(list(tab([2, 3, 4])), [0, 7, 0])
-        self.assertEqual(tab(math.nextafter(3., -math.inf)), 0.)
-        self.assertEqual(tab(math.nextafter(3.,  math.inf)), 0.)
+        self.assertEqual(tab(nextafter(3., -math.inf)), 0.)
+        self.assertEqual(tab(nextafter(3.,  math.inf)), 0.)
 
         # All zeros
 
@@ -659,7 +664,7 @@ class Test_Tabulation(unittest.TestCase):
 
         tab = Tabulation([0, 1, 1, 2], [2, 4, 1, 3])
         self.assertEqual(tab.x[1], 1)
-        self.assertEqual(tab.x[2], math.nextafter(1, np.inf))
+        self.assertEqual(tab.x[2], nextafter(1, np.inf))
         x = np.array([0.990, 0.995, 1, 1.005, 1.010])
         answer = np.array([3.98, 3.99, 4., 1.01, 1.02])
         diff = tab(x) - answer

--- a/tests/test_tabulation.py
+++ b/tests/test_tabulation.py
@@ -4,6 +4,7 @@
 
 from tabulation import Tabulation
 
+import math
 import numpy as np
 import unittest
 
@@ -158,6 +159,18 @@ class Test_Tabulation(unittest.TestCase):
                                          9., 10., 11.])))
         self.assertTrue(np.all(subsampled.y == np.array([0., 1., 2., 3., 4., 5., 6., 7.,
                                                          8., 9., 10., 0.])))
+
+        tab = Tabulation(np.arange(10.) + 0.25, [0, 0, 1, 1, 0, 1, 0, 1, 1, 2])
+        subsampled = tab.subsample(dx=1)
+        for i in range(2, 10):
+            self.assertIn(i, subsampled.x)
+
+        subsampled = tab.subsample(n=16)
+        for i in range(2, 9):
+            self.assertIn(i+0.75, subsampled.x)
+
+        subsampled = tab.subsample()
+        self.assertIs(subsampled, tab)
 
         # ADDITION
 
@@ -506,14 +519,16 @@ class Test_Tabulation(unittest.TestCase):
         y = np.array([4, 5, 6])
         with self.assertRaises(ValueError) as context:
             Tabulation(x, y)
-        self.assertEqual(str(context.exception), "x-coordinates are not monotonic")
+        self.assertEqual(str(context.exception),
+                         "x-coordinates are not strictly monotonic")
 
         # Test initialization with a non-monotonic x array (with floats)
         x = np.array([1., 3., 2.])  # Non-monotonic
         y = np.array([4., 5., 6.])
         with self.assertRaises(ValueError) as context:
             Tabulation(x, y)
-        self.assertEqual(str(context.exception), "x-coordinates are not monotonic")
+        self.assertEqual(str(context.exception),
+                         "x-coordinates are not strictly monotonic")
 
         # Test update with new_y having a different size than x
         x = np.array([1, 2, 3])
@@ -521,7 +536,7 @@ class Test_Tabulation(unittest.TestCase):
         tab = Tabulation(x, y)
         new_y = np.array([7, 8])  # Mismatched size
         with self.assertRaises(ValueError) as context:
-            tab._update_y(new_y)
+            tab._update(tab.x, new_y)
         self.assertEqual(str(context.exception),
                          "x and y arrays do not have the same size")
 
@@ -603,3 +618,49 @@ class Test_Tabulation(unittest.TestCase):
         self.assertRaises(IndexError, tab.__getitem__, -99)
         self.assertRaises(ValueError, tab.__getitem__, None)
         self.assertRaises(ValueError, tab.__getitem__, [0, 1, 5, 4])
+
+        # Delta function case
+
+        tab = Tabulation([3], [7])
+        self.assertEqual(tab.domain(), (3, 3))
+        self.assertEqual(tab(3), 7)
+        self.assertEqual(list(tab([2, 3, 4])), [0, 7, 0])
+        self.assertEqual(tab(math.nextafter(3., -math.inf)), 0.)
+        self.assertEqual(tab(math.nextafter(3.,  math.inf)), 0.)
+
+        # All zeros
+
+        tab = Tabulation(np.arange(10), np.zeros(10))
+        self.assertEqual(tab.domain(), (0, 9))
+        self.assertEqual(tab(3), 0)
+        self.assertEqual(tab(-3), 0)
+        self.assertEqual(list(tab([2, 3, 4])), [0, 0, 0])
+
+        # Duplicated end points
+
+        x = np.array([1., 1., 2., 3., 4., 4.])
+        y = np.array([0., 4., 3., 2., 1., 0.])
+        tab = Tabulation(x, y)
+        self.assertEqual(tab.domain(), (1, 4))
+        self.assertLess(tab.x[0], 1.)
+        self.assertGreater(tab.x[-1], 4.)
+
+        x = np.array([1., 1.1, 2., 3., 4., 4.])
+        y = np.array([0., 4., 3., 2., 1., 0.])
+        tab = Tabulation(x, y)
+        self.assertEqual(tab.domain(), (1, 4))
+
+        x = np.array([1., 1., 2., 3., 3.9, 4.])
+        y = np.array([0., 4., 3., 2., 1., 0.])
+        tab = Tabulation(x, y)
+        self.assertEqual(tab.domain(), (1, 4))
+
+        # Duplicated internal points
+
+        tab = Tabulation([0, 1, 1, 2], [2, 4, 1, 3])
+        self.assertEqual(tab.x[1], 1)
+        self.assertEqual(tab.x[2], math.nextafter(1, np.inf))
+        x = np.array([0.990, 0.995, 1, 1.005, 1.010])
+        answer = np.array([3.98, 3.99, 4., 1.01, 1.02])
+        diff = tab(x) - answer
+        self.assertLess(np.abs(diff).max(), 1.e-15)


### PR DESCRIPTION
# Fixed Issues

* Fixes #13 

# Summary of Changes

* `_update()` now checks for duplicated, adjacent x-values and shifts one of them by "epsilon" in order to make them different. This addresses the issue I encountered. The solution is fairly general because duplicated x can occur in the middle of the x-array as well as at an end point. When x is duplicated, it always shifts the one with y closer to zero by epsilon, so it handles the end points correctly as also makes a reasonable choice for a duplicated x in the middle of the array.
* Because tabulations are always trimmed upon construction, I realized `_trim()` was no longer needed. It's gone.
* Similarly, `_update_y()` didn't really save any effort relative to `_update()`, so it is now gone.
* I modified `domain()` so that anchor points at the end don't affect the answer.
* Meanwhile, I added two convenient input options for `subsample()`.
* Coverage is still 100%.
* I didn't really modify the documentation, but I did check the sphinx output and it looks fine.

# Known Problems

None.